### PR TITLE
Fix map field paths that contain Go format tokens

### DIFF
--- a/internal/errors/utils.go
+++ b/internal/errors/utils.go
@@ -47,10 +47,11 @@ func Merge(dst, src error, failFast bool) (ok bool, err error) {
 	return !(failFast && len(dstValErrs.Violations) > 0), dst
 }
 
-// PrefixErrorPaths prepends the prefix to the violations of a ValidationError.
-func PrefixErrorPaths(err error, prefix string) {
+// PrefixErrorPaths prepends the formatted prefix to the violations of a
+// ValidationError.
+func PrefixErrorPaths(err error, format string, args ...any) {
 	var valErr *ValidationError
 	if errors.As(err, &valErr) {
-		PrefixFieldPaths(valErr, prefix)
+		PrefixFieldPaths(valErr, format, args...)
 	}
 }

--- a/internal/evaluator/field.go
+++ b/internal/evaluator/field.go
@@ -55,7 +55,7 @@ func (f field) EvaluateMessage(msg protoreflect.Message, failFast bool) (err err
 
 	val := msg.Get(f.Descriptor)
 	if err = f.Value.Evaluate(val, failFast); err != nil {
-		errors.PrefixErrorPaths(err, string(f.Descriptor.Name()))
+		errors.PrefixErrorPaths(err, "%s", f.Descriptor.Name())
 	}
 	return err
 }

--- a/internal/evaluator/map.go
+++ b/internal/evaluator/map.go
@@ -15,8 +15,6 @@
 package evaluator
 
 import (
-	"fmt"
-
 	"github.com/bufbuild/protovalidate-go/internal/errors"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
@@ -34,7 +32,7 @@ func (m kvPairs) Evaluate(val protoreflect.Value, failFast bool) (err error) {
 	val.Map().Range(func(key protoreflect.MapKey, value protoreflect.Value) bool {
 		evalErr := m.evalPairs(key, value, failFast)
 		if evalErr != nil {
-			errors.PrefixErrorPaths(evalErr, fmt.Sprintf("[%#v]", key.Interface()))
+			errors.PrefixErrorPaths(evalErr, "[%#v]", key.Interface())
 		}
 		ok, err = errors.Merge(err, evalErr, failFast)
 		return ok

--- a/internal/evaluator/repeated.go
+++ b/internal/evaluator/repeated.go
@@ -15,8 +15,6 @@
 package evaluator
 
 import (
-	"fmt"
-
 	"github.com/bufbuild/protovalidate-go/internal/errors"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
@@ -34,7 +32,7 @@ func (r listItems) Evaluate(val protoreflect.Value, failFast bool) error {
 	for i := 0; i < list.Len(); i++ {
 		itemErr := r.ItemConstraints.Evaluate(list.Get(i), failFast)
 		if itemErr != nil {
-			errors.PrefixErrorPaths(itemErr, fmt.Sprintf("[%d]", i))
+			errors.PrefixErrorPaths(itemErr, "[%d]", i)
 		}
 		if ok, err = errors.Merge(err, itemErr, failFast); !ok {
 			return err


### PR DESCRIPTION
Fixes related to bufbuild/protovalidate#9. Formatting was being double-applied to error prefixes, causing `%`'s in field paths (such as a string map key) to be mangled.