### PR TITLE
Build validator copy cache on write

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,11 @@ validator, err := protovalidate.New(
 )
 ```
 
-Lazy mode requires usage of a mutex to keep the validator thread-safe, which 
-results in about 50% of CPU time spent obtaining a read lock. While [performance](#performance)
-is sub-microsecond, the mutex overhead can be further reduced by disabling lazy 
-mode with the `WithDisableLazy` option. Note that all expected messages must be
-provided during initialization of the validator:
+Lazy mode uses a copy on write cache stategy to reduce the required locking.
+While [performance](#performance) is sub-microsecond, the overhead can be
+further reduced by disabling lazy mode with the `WithDisableLazy` option.
+Note that all expected messages must be provided during initialization of the
+validator:
 
 ```go
 validator, err := protovalidate.New(
@@ -200,25 +200,17 @@ initial cold start, validation on a message is sub-microsecond
 and only allocates in the event of a validation error.
 
 ```
-[circa 15 May 2023]
+[circa 24 August 2023]
 goos: darwin
 goarch: arm64
 pkg: github.com/bufbuild/protovalidate-go
-BenchmarkValidator
-BenchmarkValidator/ColdStart
-BenchmarkValidator/ColdStart-10         	    4372	    276457 ns/op	  470780 B/op	    9255 allocs/op
-BenchmarkValidator/Lazy/Valid
-BenchmarkValidator/Lazy/Valid-10        	 9022392	     134.1 ns/op	       0 B/op	       0 allocs/op
-BenchmarkValidator/Lazy/Invalid
-BenchmarkValidator/Lazy/Invalid-10      	 3416996	     355.9 ns/op	     632 B/op	      14 allocs/op
-BenchmarkValidator/Lazy/FailFast
-BenchmarkValidator/Lazy/FailFast-10     	 6751131	     172.6 ns/op	     168 B/op	       3 allocs/op
-BenchmarkValidator/PreWarmed/Valid
-BenchmarkValidator/PreWarmed/Valid-10   	17557560	     69.10 ns/op	       0 B/op	       0 allocs/op
-BenchmarkValidator/PreWarmed/Invalid
-BenchmarkValidator/PreWarmed/Invalid-10 	 3621961	     332.9 ns/op	     632 B/op	      14 allocs/op
-BenchmarkValidator/PreWarmed/FailFast
-BenchmarkValidator/PreWarmed/FailFast-10	13960359	     92.22 ns/op	     168 B/op	       3 allocs/op
+BenchmarkValidator/ColdStart-8              5294            219906 ns/op          431759 B/op       5803 allocs/op
+BenchmarkValidator/Lazy/Valid-8          9725028               114.7 ns/op             0 B/op          0 allocs/op
+BenchmarkValidator/Lazy/Invalid-8        3060620               383.5 ns/op           649 B/op         15 allocs/op
+BenchmarkValidator/Lazy/FailFast-8      11999664                98.17 ns/op          168 B/op          3 allocs/op
+BenchmarkValidator/PreWarmed/Valid-8    11031498               112.0 ns/op             0 B/op          0 allocs/op
+BenchmarkValidator/PreWarmed/Invalid-8   3132213               391.1 ns/op           649 B/op         15 allocs/op
+BenchmarkValidator/PreWarmed/FailFast-8 12277747                99.36 ns/op          168 B/op          3 allocs/op
 PASS
 ```
 

--- a/internal/evaluator/builder_test.go
+++ b/internal/evaluator/builder_test.go
@@ -1,0 +1,138 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package evaluator
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/bufbuild/protovalidate-go/internal/celext"
+	pb "github.com/bufbuild/protovalidate-go/internal/gen/tests/example/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+func TestBuildCache(t *testing.T) {
+	t.Parallel()
+
+	env, err := celext.DefaultEnv(true)
+	require.NoError(t, err, "failed to construct CEL environment")
+	bldr := NewBuilder(
+		env, false, DefaultResolver{},
+	)
+	wg := sync.WaitGroup{}
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		dynamicMsg := dynamicProto{&pb.Person{
+			Id:    1234,
+			Email: "protovalidate@buf.build",
+			Name:  "Protocol Buffer",
+		}, int32(i)}
+		desc := dynamicMsg.ProtoReflect().Descriptor()
+		go func() {
+			defer wg.Done()
+			eval := bldr.Load(desc)
+			assert.NotNil(t, eval)
+		}()
+	}
+	wg.Wait()
+}
+
+type dynamicProto struct {
+	proto.Message
+	salt int32
+}
+
+func (d dynamicProto) ProtoReflect() protoreflect.Message {
+	return dynamicMessage{d.Message.ProtoReflect(), d.salt}
+}
+
+type dynamicMessage struct {
+	protoreflect.Message
+	salt int32
+}
+
+func (d dynamicMessage) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	d.Message.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+		return f(dynamicFieldDescriptor{fd, d.salt}, v)
+	})
+}
+
+func (d dynamicMessage) Has(fd protoreflect.FieldDescriptor) bool {
+	return d.Message.Has(unwrapFieldDescriptor(fd))
+}
+func (d dynamicMessage) Clear(fd protoreflect.FieldDescriptor) {
+	d.Message.Clear(unwrapFieldDescriptor(fd))
+}
+func (d dynamicMessage) Get(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	return d.Message.Get(unwrapFieldDescriptor(fd))
+}
+func (d dynamicMessage) Set(fd protoreflect.FieldDescriptor, v protoreflect.Value) {
+	d.Message.Set(unwrapFieldDescriptor(fd), v)
+}
+func (d dynamicMessage) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	return d.Message.Mutable(unwrapFieldDescriptor(fd))
+}
+func (d dynamicMessage) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	return d.Message.NewField(unwrapFieldDescriptor(fd))
+}
+
+func (d dynamicMessage) Descriptor() protoreflect.MessageDescriptor {
+	return dynamicMessageDescriptor{d.Message.Descriptor(), d.salt}
+}
+
+type dynamicMessageDescriptor struct {
+	protoreflect.MessageDescriptor
+	salt int32
+}
+
+func (d dynamicMessageDescriptor) Fields() protoreflect.FieldDescriptors {
+	return dynamicFieldDescriptors{d.MessageDescriptor.Fields(), d.salt}
+}
+
+type dynamicFieldDescriptors struct {
+	protoreflect.FieldDescriptors
+	salt int32
+}
+
+func (d dynamicFieldDescriptors) Get(i int) protoreflect.FieldDescriptor {
+	return dynamicFieldDescriptor{d.FieldDescriptors.Get(i), d.salt}
+}
+func (d dynamicFieldDescriptors) ByName(s protoreflect.Name) protoreflect.FieldDescriptor {
+	return dynamicFieldDescriptor{d.FieldDescriptors.ByName(s), d.salt}
+}
+func (d dynamicFieldDescriptors) ByJSONName(s string) protoreflect.FieldDescriptor {
+	return dynamicFieldDescriptor{d.FieldDescriptors.ByJSONName(s), d.salt}
+}
+func (d dynamicFieldDescriptors) ByTextName(s string) protoreflect.FieldDescriptor {
+	return dynamicFieldDescriptor{d.FieldDescriptors.ByTextName(s), d.salt}
+}
+func (d dynamicFieldDescriptors) ByNumber(n protoreflect.FieldNumber) protoreflect.FieldDescriptor {
+	return dynamicFieldDescriptor{d.FieldDescriptors.ByNumber(n), d.salt}
+}
+
+type dynamicFieldDescriptor struct {
+	protoreflect.FieldDescriptor
+	salt int32
+}
+
+func unwrapFieldDescriptor(fd protoreflect.FieldDescriptor) protoreflect.FieldDescriptor {
+	if d, ok := fd.(dynamicFieldDescriptor); ok {
+		return d.FieldDescriptor
+	}
+	return fd
+}

--- a/internal/evaluator/message.go
+++ b/internal/evaluator/message.go
@@ -15,16 +15,12 @@
 package evaluator
 
 import (
-	"sync"
-
 	"github.com/bufbuild/protovalidate-go/internal/errors"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 // message performs validation on a protoreflect.Message.
 type message struct {
-	sync.WaitGroup
-
 	// Err stores if there was a compilation error constructing this evaluator.
 	// It is cached here so that it can be stored in the registry's lookup table.
 	Err error

--- a/internal/evaluator/message.go
+++ b/internal/evaluator/message.go
@@ -15,12 +15,16 @@
 package evaluator
 
 import (
+	"sync"
+
 	"github.com/bufbuild/protovalidate-go/internal/errors"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 // message performs validation on a protoreflect.Message.
 type message struct {
+	sync.WaitGroup
+
 	// Err stores if there was a compilation error constructing this evaluator.
 	// It is cached here so that it can be stored in the registry's lookup table.
 	Err error


### PR DESCRIPTION
This was just fun to play with: Swap cache map on write. 😬 

Also tried a waitgroup, but that has worse performance than the r/w lock.
 
Idea for: https://github.com/bufbuild/protovalidate-go/issues/29

```
goos: darwin
goarch: arm64
pkg: github.com/bufbuild/protovalidate-go
                               │  current.txt  │               new.txt                │
                               │    sec/op     │    sec/op     vs base                │
Validator/ColdStart-8             210.9µ ± ∞ ¹   211.8µ ± ∞ ¹       ~ (p=1.000 n=1) ²
Validator/Lazy/Valid-8            136.1n ± ∞ ¹   104.3n ± ∞ ¹       ~ (p=1.000 n=1) ²
Validator/Lazy/Invalid-8          391.9n ± ∞ ¹   386.9n ± ∞ ¹       ~ (p=1.000 n=1) ²
Validator/Lazy/FailFast-8        136.90n ± ∞ ¹   97.42n ± ∞ ¹       ~ (p=1.000 n=1) ²
Validator/PreWarmed/Valid-8       101.1n ± ∞ ¹   102.8n ± ∞ ¹       ~ (p=1.000 n=1) ²
Validator/PreWarmed/Invalid-8     382.5n ± ∞ ¹   385.7n ± ∞ ¹       ~ (p=1.000 n=1) ²
Validator/PreWarmed/FailFast-8    93.68n ± ∞ ¹   95.46n ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                           476.5n         439.2n        -7.84%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                               │  current.txt  │                new.txt                │
                               │     B/op      │     B/op       vs base                │
Validator/ColdStart-8            421.4Ki ± ∞ ¹   421.4Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
Validator/Lazy/Valid-8             0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ³
Validator/Lazy/Invalid-8           649.0 ± ∞ ¹     649.0 ± ∞ ¹       ~ (p=1.000 n=1) ³
Validator/Lazy/FailFast-8          168.0 ± ∞ ¹     168.0 ± ∞ ¹       ~ (p=1.000 n=1) ³
Validator/PreWarmed/Valid-8        0.000 ± ∞ ¹     0.000 ± ∞ ¹       ~ (p=1.000 n=1) ³
Validator/PreWarmed/Invalid-8      648.0 ± ∞ ¹     649.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
Validator/PreWarmed/FailFast-8     168.0 ± ∞ ¹     168.0 ± ∞ ¹       ~ (p=1.000 n=1) ³
geomean                                      ⁴                  +0.02%               ⁴
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
³ all samples are equal
⁴ summaries must be >0 to compute geomean

                               │ current.txt  │               new.txt                │
                               │  allocs/op   │  allocs/op    vs base                │
Validator/ColdStart-8            5.798k ± ∞ ¹   5.800k ± ∞ ¹       ~ (p=1.000 n=1) ²
Validator/Lazy/Valid-8            0.000 ± ∞ ¹    0.000 ± ∞ ¹       ~ (p=1.000 n=1) ³
Validator/Lazy/Invalid-8          15.00 ± ∞ ¹    15.00 ± ∞ ¹       ~ (p=1.000 n=1) ³
Validator/Lazy/FailFast-8         3.000 ± ∞ ¹    3.000 ± ∞ ¹       ~ (p=1.000 n=1) ³
Validator/PreWarmed/Valid-8       0.000 ± ∞ ¹    0.000 ± ∞ ¹       ~ (p=1.000 n=1) ³
Validator/PreWarmed/Invalid-8     15.00 ± ∞ ¹    15.00 ± ∞ ¹       ~ (p=1.000 n=1) ³
Validator/PreWarmed/FailFast-8    3.000 ± ∞ ¹    3.000 ± ∞ ¹       ~ (p=1.000 n=1) ³
geomean                                     ⁴                 +0.00%               ⁴
```