### PR TITLE
Bypass deprecation lint warning

### DIFF
--- a/internal/celext/lib.go
+++ b/internal/celext/lib.go
@@ -268,7 +268,7 @@ func (l lib) ProgramOptions() []cel.ProgramOption {
 	return []cel.ProgramOption{
 		cel.EvalOptions(
 			cel.OptOptimize,
-			cel.OptCheckStringFormat,
+			cel.OptCheckStringFormat, //nolint:staticcheck
 		),
 	}
 }


### PR DESCRIPTION
CI is failing because of a deprecation notice on `cel.OptCheckStringFormat`, but the recommended alternative doesn't
appear to exist. I've filed https://github.com/google/cel-go/issues/837 upstream to clarify, but for now tests are passing so I think we can safely bypass this lint error.

I also filed https://github.com/bufbuild/protovalidate-go/issues/44 so that we don't forget to migrate to whichever API is recommended and remove this bypass.
