### PR TITLE
Make constraint resolution more flexible to different concrete extension types

### DIFF
--- a/internal/evaluator/resolver.go
+++ b/internal/evaluator/resolver.go
@@ -20,7 +20,6 @@ import (
 	"buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go/buf/validate"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
-	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/runtime/protoimpl"
 )
 
@@ -70,39 +69,25 @@ func resolveExt[D protoreflect.Descriptor, C proto.Message](
 	desc D,
 	extType protoreflect.ExtensionType,
 ) (constraints C) {
-	opts := desc.Options().ProtoReflect()
-	fDesc := extType.TypeDescriptor()
-
-	if opts.Has(fDesc) {
-		msg := opts.Get(fDesc).Message().Interface()
-		if m, ok := msg.(C); ok {
-			return m
+	num := extType.TypeDescriptor().Number()
+	var msg proto.Message
+	proto.RangeExtensions(desc.Options(), func(typ protoreflect.ExtensionType, i interface{}) bool {
+		if num != typ.TypeDescriptor().Number() {
+			return true
 		}
-	}
+		msg, _ = i.(proto.Message)
+		return false
+	})
 
-	unknown := opts.GetUnknown()
-	if len(unknown) == 0 {
+	if msg == nil {
 		return constraints
-	}
-
-	opts = opts.Type().New()
-	var resolver protoregistry.Types
-	if err := resolver.RegisterExtension(extType); err != nil {
-		return constraints
-	}
-	_ = proto.UnmarshalOptions{Resolver: &resolver}.Unmarshal(unknown, opts.Interface())
-
-	if opts.Has(fDesc) {
-		msg := opts.Get(fDesc).Message().Interface()
-		if m, ok := msg.(C); ok {
-			return m
-		}
-	}
-	msg := opts.Get(fDesc).Message().Interface()
-	if m, ok := msg.(C); ok {
+	} else if m, ok := msg.(C); ok {
 		return m
 	}
 
+	constraints = constraints.ProtoReflect().New().Interface().(C)
+	b, _ := proto.Marshal(msg)
+	_ = proto.Unmarshal(b, constraints)
 	return constraints
 }
 

--- a/internal/evaluator/resolver.go
+++ b/internal/evaluator/resolver.go
@@ -85,7 +85,7 @@ func resolveExt[D protoreflect.Descriptor, C proto.Message](
 		return m
 	}
 
-	constraints = constraints.ProtoReflect().New().Interface().(C)
+	constraints, _ = constraints.ProtoReflect().New().Interface().(C)
 	b, _ := proto.Marshal(msg)
 	_ = proto.Unmarshal(b, constraints)
 	return constraints


### PR DESCRIPTION
The go proto library struggles to resolve values for extensions if the concrete type associated with the generated source code on hand does not match that on the descriptor of the message in question (which happens in cases where the descriptor or message is produced at runtime). This manifested in the protovalidate resolver where the extension could not be found on options attached to a descriptor produced dynamically.

Unfortunately, I struggled to find a way to get the extension and its value directly. (I'm not even sure how to get the field/ext descriptor from the descriptor; `protoreflect.Fields.ByNumber` doesn't work). The most straightforward solution from a few iterations was to leverage `proto.RangeExtensions`. 

There's room here for some mild optimization to short circuit in most vanilla situations but it makes it a bit less readable. Since this only happens once per descriptor, the optimization is overkill IMO.