### PR TITLE
Update minimum required Go version from 1.18 to 1.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ And others coming soon:
 
 ## Installation
 
-**Requires the `go` toolchain (≥ v1.18)**
+**Requires the `go` toolchain (≥ v1.19)**
 
 To install the package, use the `go get` command from within your Go module:
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bufbuild/protovalidate-go
 
-go 1.18
+go 1.19
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.31.0-20230914171853-63dfe56cc2c4.1


### PR DESCRIPTION
Fixes https://github.com/bufbuild/protovalidate-go/issues/61