### PR TITLE
Fix ignore path for resolver.go

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -78,7 +78,7 @@ issues:
     - path: internal/constraints/lookups.go
       linters:
         - gochecknoglobals
-    - path: internal/evaluator/resolver.go
+    - path: resolver/resolver.go
       linters:
         # uses deprecated fields on protoimpl.ExtensionInfo but its the only way
         - staticcheck


### PR DESCRIPTION
resolver.go was moved in https://github.com/bufbuild/protovalidate-go/pull/59 but this ignore path didn't get updated so lint started failing. This fixes that so lint is passing again.