### PR TITLE
Fix CI lint

### DIFF
--- a/internal/constraints/cache_test.go
+++ b/internal/constraints/cache_test.go
@@ -103,9 +103,9 @@ func TestCache_BuildStandardConstraints(t *testing.T) {
 
 			set, err := c.Build(env, test.desc, test.cons, test.forItems)
 			if test.exErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Len(t, set, test.exCt)
 			}
 		})
@@ -127,7 +127,7 @@ func TestCache_LoadOrCompileStandardConstraint(t *testing.T) {
 	assert.False(t, ok)
 
 	asts, err := cache.loadOrCompileStandardConstraint(env, desc)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, asts)
 
 	cached, ok := cache.cache[desc]
@@ -135,7 +135,7 @@ func TestCache_LoadOrCompileStandardConstraint(t *testing.T) {
 	assert.Equal(t, cached, asts)
 
 	asts, err = cache.loadOrCompileStandardConstraint(env, desc)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, cached, asts)
 }
 

--- a/internal/errors/utils_test.go
+++ b/internal/errors/utils_test.go
@@ -30,10 +30,10 @@ func TestMerge(t *testing.T) {
 	t.Run("no errors", func(t *testing.T) {
 		t.Parallel()
 		ok, err := Merge(nil, nil, true)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, ok)
 		ok, err = Merge(nil, nil, false)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, ok)
 	})
 

--- a/internal/errors/validation.go
+++ b/internal/errors/validation.go
@@ -30,13 +30,13 @@ func (err *ValidationError) Error() string {
 	bldr.WriteString("validation error:")
 	for _, violation := range err.Violations {
 		bldr.WriteString("\n - ")
-		if violation.FieldPath != "" {
-			bldr.WriteString(violation.FieldPath)
+		if violation.GetFieldPath() != "" {
+			bldr.WriteString(violation.GetFieldPath())
 			bldr.WriteString(": ")
 		}
 		_, _ = fmt.Fprintf(bldr, "%s [%s]",
-			violation.Message,
-			violation.ConstraintId)
+			violation.GetMessage(),
+			violation.GetConstraintId())
 	}
 	return bldr.String()
 }
@@ -52,12 +52,12 @@ func PrefixFieldPaths(err *ValidationError, format string, args ...any) {
 	prefix := fmt.Sprintf(format, args...)
 	for _, violation := range err.Violations {
 		switch {
-		case violation.FieldPath == "": // no existing field path
+		case violation.GetFieldPath() == "": // no existing field path
 			violation.FieldPath = prefix
-		case violation.FieldPath[0] == '[': // field is a map/list
-			violation.FieldPath = prefix + violation.FieldPath
+		case violation.GetFieldPath()[0] == '[': // field is a map/list
+			violation.FieldPath = prefix + violation.GetFieldPath()
 		default: // any other field
-			violation.FieldPath = fmt.Sprintf("%s.%s", prefix, violation.FieldPath)
+			violation.FieldPath = fmt.Sprintf("%s.%s", prefix, violation.GetFieldPath())
 		}
 	}
 }

--- a/internal/errors/validation_test.go
+++ b/internal/errors/validation_test.go
@@ -66,7 +66,7 @@ func TestPrefixFieldPaths(t *testing.T) {
 			}}
 			PrefixFieldPaths(err, test.format, test.args...)
 			for _, v := range err.Violations {
-				assert.Equal(t, test.expected, v.FieldPath)
+				assert.Equal(t, test.expected, v.GetFieldPath())
 			}
 		})
 	}

--- a/internal/expression/ast_test.go
+++ b/internal/expression/ast_test.go
@@ -71,7 +71,7 @@ func TestASTSet_ToProgramSet(t *testing.T) {
 	empty := ASTSet{}
 	set, err = empty.ToProgramSet()
 	assert.Empty(t, set)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestASTSet_ReduceResiduals(t *testing.T) {
@@ -86,6 +86,6 @@ func TestASTSet_ReduceResiduals(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, asts.asts, 1)
 	set, err := asts.ReduceResiduals(cel.Globals(&Variable{Name: "foo", Val: true}))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, set)
 }

--- a/internal/expression/compile_test.go
+++ b/internal/expression/compile_test.go
@@ -36,7 +36,7 @@ func TestCompile(t *testing.T) {
 		var exprs []*validate.Constraint
 		set, err := Compile(exprs, baseEnv)
 		assert.Nil(t, set)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("success", func(t *testing.T) {
@@ -47,7 +47,7 @@ func TestCompile(t *testing.T) {
 		}
 		set, err := Compile(exprs, baseEnv, cel.Variable("this", cel.IntType))
 		assert.Len(t, set, len(exprs))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("env extension err", func(t *testing.T) {
@@ -58,7 +58,7 @@ func TestCompile(t *testing.T) {
 		set, err := Compile(exprs, baseEnv, cel.Types(true))
 		assert.Nil(t, set)
 		var compErr *errors.CompilationError
-		assert.ErrorAs(t, err, &compErr)
+		require.ErrorAs(t, err, &compErr)
 	})
 
 	t.Run("bad syntax", func(t *testing.T) {
@@ -69,7 +69,7 @@ func TestCompile(t *testing.T) {
 		set, err := Compile(exprs, baseEnv)
 		assert.Nil(t, set)
 		var compErr *errors.CompilationError
-		assert.ErrorAs(t, err, &compErr)
+		require.ErrorAs(t, err, &compErr)
 	})
 
 	t.Run("invalid output type", func(t *testing.T) {
@@ -80,6 +80,6 @@ func TestCompile(t *testing.T) {
 		set, err := Compile(exprs, baseEnv)
 		assert.Nil(t, set)
 		var compErr *errors.CompilationError
-		assert.ErrorAs(t, err, &compErr)
+		require.ErrorAs(t, err, &compErr)
 	})
 }

--- a/legacy/resolver_test.go
+++ b/legacy/resolver_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/bufbuild/protovalidate-go"
 	examplev1 "github.com/bufbuild/protovalidate-go/internal/gen/tests/example/v1"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
@@ -131,9 +130,9 @@ func TestWithLegacySupport(t *testing.T) {
 			err = val.Validate(test.msg)
 			if test.exErr {
 				valErr := &protovalidate.ValidationError{}
-				assert.ErrorAs(t, err, &valErr)
+				require.ErrorAs(t, err, &valErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/validator_bench_test.go
+++ b/validator_bench_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	pb "github.com/bufbuild/protovalidate-go/internal/gen/tests/example/v1"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,7 +32,7 @@ func BenchmarkValidator(b *testing.B) {
 				val, err := New()
 				require.NoError(b, err)
 				err = val.Validate(successMsg)
-				assert.NoError(b, err)
+				require.NoError(b, err)
 			}
 		})
 	})
@@ -46,7 +45,7 @@ func BenchmarkValidator(b *testing.B) {
 		b.RunParallel(func(p *testing.PB) {
 			for p.Next() {
 				err := val.Validate(successMsg)
-				assert.NoError(b, err)
+				require.NoError(b, err)
 			}
 		})
 	})
@@ -59,7 +58,7 @@ func BenchmarkValidator(b *testing.B) {
 		b.RunParallel(func(p *testing.PB) {
 			for p.Next() {
 				err := val.Validate(failureMsg)
-				assert.Error(b, err)
+				require.Error(b, err)
 			}
 		})
 	})
@@ -72,7 +71,7 @@ func BenchmarkValidator(b *testing.B) {
 		b.RunParallel(func(p *testing.PB) {
 			for p.Next() {
 				err := val.Validate(failureMsg)
-				assert.Error(b, err)
+				require.Error(b, err)
 			}
 		})
 	})
@@ -88,7 +87,7 @@ func BenchmarkValidator(b *testing.B) {
 		b.RunParallel(func(p *testing.PB) {
 			for p.Next() {
 				err := val.Validate(successMsg)
-				assert.NoError(b, err)
+				require.NoError(b, err)
 			}
 		})
 	})
@@ -104,7 +103,7 @@ func BenchmarkValidator(b *testing.B) {
 		b.RunParallel(func(p *testing.PB) {
 			for p.Next() {
 				err := val.Validate(failureMsg)
-				assert.Error(b, err)
+				require.Error(b, err)
 			}
 		})
 	})
@@ -121,7 +120,7 @@ func BenchmarkValidator(b *testing.B) {
 		b.RunParallel(func(p *testing.PB) {
 			for p.Next() {
 				err := val.Validate(failureMsg)
-				assert.Error(b, err)
+				require.Error(b, err)
 			}
 		})
 	})

--- a/validator_example_test.go
+++ b/validator_example_test.go
@@ -141,7 +141,7 @@ func ExampleWithDisableLazy() {
 		log.Fatal(err)
 	}
 
-	err = validator.Validate(person.Home)
+	err = validator.Validate(person.GetHome())
 	fmt.Println("person.Home:", err)
 	err = validator.Validate(person)
 	fmt.Println("person:", err)
@@ -162,7 +162,7 @@ func ExampleValidationError() {
 	var valErr *ValidationError
 	if ok := errors.As(err, &valErr); ok {
 		msg := valErr.ToProto()
-		fmt.Println(msg.Violations[0].FieldPath, msg.Violations[0].ConstraintId)
+		fmt.Println(msg.GetViolations()[0].GetFieldPath(), msg.GetViolations()[0].GetConstraintId())
 	}
 
 	// output: lat double.gte_lte

--- a/validator_test.go
+++ b/validator_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	pb "github.com/bufbuild/protovalidate-go/internal/gen/tests/example/v1"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/apipb"
@@ -51,9 +50,9 @@ func TestValidator_Validate(t *testing.T) {
 		for _, test := range tests {
 			err := val.Validate(test.msg)
 			if test.exErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		}
 	})
@@ -66,11 +65,11 @@ func TestRecursive(t *testing.T) {
 
 	selfRec := &pb.SelfRecursive{X: 123, Turtle: &pb.SelfRecursive{X: 456}}
 	err = val.Validate(selfRec)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loopRec := &pb.LoopRecursiveA{B: &pb.LoopRecursiveB{}}
 	err = val.Validate(loopRec)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestValidator_ValidateOneof(t *testing.T) {
@@ -79,19 +78,19 @@ func TestValidator_ValidateOneof(t *testing.T) {
 	require.NoError(t, err)
 	oneofMessage := &pb.MsgHasOneof{O: &pb.MsgHasOneof_X{X: "foo"}}
 	err = val.Validate(oneofMessage)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	oneofMessage = &pb.MsgHasOneof{O: &pb.MsgHasOneof_Y{Y: 42}}
 	err = val.Validate(oneofMessage)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	oneofMessage = &pb.MsgHasOneof{O: &pb.MsgHasOneof_Msg{Msg: &pb.HasMsgExprs{X: 4, Y: 50}}}
 	err = val.Validate(oneofMessage)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	oneofMessage = &pb.MsgHasOneof{}
 	err = val.Validate(oneofMessage)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestValidator_ValidateRepeatedFoo(t *testing.T) {


### PR DESCRIPTION
This fixes lint errors reported by `testifylint` and `protogetter`, added in [golangci-lint v1.55.0](https://github.com/golangci/golangci-lint/releases/tag/v1.55.0).

The PR fixes everything it reports without adding anything to `exclude-rules` to `.golangci.yml`.