### PR TITLE
Use make lint in CI instead of golangci-lint action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,12 +34,4 @@ jobs:
         # Often, lint guidelines depend on the Go version. To prevent
         # conflicting guidance, run only on the most recent supported version.
         if: matrix.go-version == 'stable'
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.52.2
-          skip-pkg-cache: true
-          only-new-issues: true
-          args: >
-            --modules-download-mode=readonly
-            --timeout=3m0s
-            ./... 
+        run: make lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,7 @@ jobs:
         if: matrix.go-version == 'stable'
         uses: golangci/golangci-lint-action@v3
         with:
+          version: v1.52.2
           skip-pkg-cache: true
           only-new-issues: true
           args: >

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ lint: lint-proto lint-go  ## Lint code and protos
 
 .PHONY: lint-go
 lint-go: $(BIN)/golangci-lint
-	$(BIN)/golangci-lint run ./...
+	$(BIN)/golangci-lint run --modules-download-mode=readonly --timeout=3m0s ./...
 
 .PHONY: lint-proto
 lint-proto: $(BIN)/buf
@@ -92,7 +92,7 @@ $(BIN)/license-header: $(BIN) Makefile
 	GOBIN=$(abspath $(@D)) $(GO) install \
 		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@latest
 
-$(BIN)/golangci-lint: $(BIN) Makefile ## Upgrade golangci/golangci-lint-action@v3 as well, whenever this is upgraded.
+$(BIN)/golangci-lint: $(BIN) Makefile
 	GOBIN=$(abspath $(@D)) $(GO) install \
 		github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
 

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ $(BIN)/license-header: $(BIN) Makefile
 	GOBIN=$(abspath $(@D)) $(GO) install \
 		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@latest
 
-$(BIN)/golangci-lint: $(BIN) Makefile ## Upgrade golangci/golangci-lint-action@v3' as well, whenever this is upgraded.
+$(BIN)/golangci-lint: $(BIN) Makefile ## Upgrade golangci/golangci-lint-action@v3 as well, whenever this is upgraded.
 	GOBIN=$(abspath $(@D)) $(GO) install \
 		github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
 

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ $(BIN)/license-header: $(BIN) Makefile
 	GOBIN=$(abspath $(@D)) $(GO) install \
 		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@latest
 
-$(BIN)/golangci-lint: $(BIN) Makefile
+$(BIN)/golangci-lint: $(BIN) Makefile ## Upgrade golangci/golangci-lint-action@v3' as well, whenever this is upgraded.
 	GOBIN=$(abspath $(@D)) $(GO) install \
 		github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
 


### PR DESCRIPTION
Run `make lint` in CI instead of using the action to make sure CI is consistent with running `make lint` locally.