### PR TITLE
Fix email validation

### DIFF
--- a/celext/lib.go
+++ b/celext/lib.go
@@ -375,7 +375,7 @@ func (l lib) uniqueBytes(list traits.Lister) ref.Val {
 
 func (l lib) validateEmail(addr string) bool {
 	a, err := mail.ParseAddress(addr)
-	if err != nil || strings.ContainsRune(addr, '<') {
+	if err != nil || strings.ContainsRune(addr, '<') || a.Address != addr {
 		return false
 	}
 

--- a/celext/lib_test.go
+++ b/celext/lib_test.go
@@ -177,6 +177,22 @@ func TestCELLib(t *testing.T) {
 				"'1.2.3.0/24'.isIpPrefix(6)",
 				false,
 			},
+			{
+				"'foo@example.com'.isEmail()",
+				true,
+			},
+			{
+				"'<foo@example.com>'.isEmail()",
+				false,
+			},
+			{
+				"'  foo@example.com'.isEmail()",
+				false,
+			},
+			{
+				"'foo@example.com    '.isEmail()",
+				false,
+			},
 		}
 
 		for _, tc := range tests {


### PR DESCRIPTION
This pull request fixes email validation (`celext.validateEmail`).

I found that some unexpected strings like `foo@example.com    ` (with trailing spaces) got allowed by the email validation, those should not be valid.

`mail.ParseAddress` can parse the string without any errors and the result's address (`a.Address` ) is valid, but it's already different from the original string, so I think checking if `a.Address` and the original `addr` is same is necessary.
