### PR TITLE
Bump Go min version to 1.20

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.19.x, oldstable, stable ]
+        go-version: [ 1.20.x, 1.21.x, 1.22.x ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -33,5 +33,5 @@ jobs:
       - name: Lint
         # Often, lint guidelines depend on the Go version. To prevent
         # conflicting guidance, run only on the most recent supported version.
-        if: matrix.go-version == 'stable'
+        if: matrix.go-version == '1.22.x'
         run: make lint

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bufbuild/protovalidate-go
 
-go 1.19
+go 1.20
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.33.0-20240221180331-f05a6f4403ce.1


### PR DESCRIPTION
Updates the CI matrix to explicitly use 1.20 through 1.22 and drops 1.19.