### PR TITLE
Export lib type

### DIFF
--- a/celext/lib_test.go
+++ b/celext/lib_test.go
@@ -26,7 +26,7 @@ import (
 func TestCELLib(t *testing.T) {
 	t.Parallel()
 
-	env, err := cel.NewEnv(cel.Lib(lib{}))
+	env, err := cel.NewEnv(cel.Lib(Lib{}))
 	require.NoError(t, err)
 
 	t.Run("ext", func(t *testing.T) {


### PR DESCRIPTION
This PR exports the `lib` type (now `Lib`) so that the Buf CLI can call

```
cel.NewEnv(
    cel.Lib(celext.Lib{
        useUTC: useUTC,
    }),
)
```
without having to include the `cel.TypeDescs(protoregistry.GlobalFiles)` option (which `celext.DefaultEnv` always include).

The Buf CLI does not want this option, here's an example to illustrate this:

If I am working on `registry-proto` and I'm adding a field to `buf.registry.module.v1.Module`, call it `foo` string, and I am also adding a CEL rule on the message level, `this.foo != ''`. 

Now I run `buf lint` and the CLI fails to compile this expression:

The linter tries to compile the expression in an env with `cel.TypeDescs(protoregistry.GlobalFiles)`.  Among these type descriptors there already is a `buf.registry.module.v1.Module`, but this comes from the generated Go type that the CLI depend on, not the `registry-proto` I'm working on.