### PR TITLE
Re-export FieldPathString

### DIFF
--- a/error_utils.go
+++ b/error_utils.go
@@ -126,9 +126,9 @@ func finalizeViolationPaths(err error) {
 	}
 }
 
-// fieldPathString takes a FieldPath and encodes it to a string-based dotted
+// FieldPathString takes a FieldPath and encodes it to a string-based dotted
 // field path.
-func fieldPathString(path []*validate.FieldPathElement) string {
+func FieldPathString(path []*validate.FieldPathElement) string {
 	var result strings.Builder
 	for i, element := range path {
 		if i > 0 {

--- a/validation_error.go
+++ b/validation_error.go
@@ -32,7 +32,7 @@ func (err *ValidationError) Error() string {
 	bldr.WriteString("validation error:")
 	for _, violation := range err.Violations {
 		bldr.WriteString("\n - ")
-		if fieldPath := fieldPathString(violation.Proto.GetField().GetElements()); fieldPath != "" {
+		if fieldPath := FieldPathString(violation.Proto.GetField().GetElements()); fieldPath != "" {
 			bldr.WriteString(fieldPath)
 			bldr.WriteString(": ")
 		}


### PR DESCRIPTION
It turns out we wind up needing this function quite a lot (e.g. it's used in Buf CLI) and I've gotten feedback that it is important for many uses. We'll need an equivalent public function for this in each runtime.