### PR TITLE
Validate URI query string encoding

### DIFF
--- a/cel/library.go
+++ b/cel/library.go
@@ -488,11 +488,8 @@ func (l library) validateURI(val string, checkAbs bool) bool {
 			return false
 		}
 	}
-	if _, err := url.ParseQuery(uri.RawQuery); err != nil {
-		return false
-	}
-
-	return true
+	_, err := url.ParseQuery(uri.RawQuery)
+	return err == nil
 }
 
 func (l library) isHostAndPort(val string, portRequired bool) bool {

--- a/cel/library.go
+++ b/cel/library.go
@@ -232,8 +232,7 @@ func (l library) CompileOptions() []cel.EnvOption {
 					if !ok {
 						return types.Bool(false)
 					}
-					uri, err := url.Parse(s)
-					return types.Bool(err == nil && uri.IsAbs())
+					return types.Bool(l.validateUri(s, true))
 				}),
 			),
 		),
@@ -247,8 +246,7 @@ func (l library) CompileOptions() []cel.EnvOption {
 					if !ok {
 						return types.Bool(false)
 					}
-					_, err := url.Parse(s)
-					return types.Bool(err == nil)
+					return types.Bool(l.validateUri(s, false))
 				}),
 			),
 		),
@@ -477,6 +475,24 @@ func (l library) validateIPPrefix(p string, ver int64, strict bool) bool {
 	default:
 		return false
 	}
+}
+
+func (l library) validateUri(val string, checkAbs bool) bool {
+	uri, err := url.Parse(val)
+	if err != nil {
+		return false
+	}
+	if checkAbs {
+		ok := uri.IsAbs()
+		if !ok {
+			return false
+		}
+	}
+	if _, err := url.ParseQuery(uri.RawQuery); err != nil {
+		return false
+	}
+
+	return true
 }
 
 func (l library) isHostAndPort(val string, portRequired bool) bool {

--- a/cel/library.go
+++ b/cel/library.go
@@ -232,7 +232,7 @@ func (l library) CompileOptions() []cel.EnvOption {
 					if !ok {
 						return types.Bool(false)
 					}
-					return types.Bool(l.validateUri(s, true))
+					return types.Bool(l.validateURI(s, true))
 				}),
 			),
 		),
@@ -246,7 +246,7 @@ func (l library) CompileOptions() []cel.EnvOption {
 					if !ok {
 						return types.Bool(false)
 					}
-					return types.Bool(l.validateUri(s, false))
+					return types.Bool(l.validateURI(s, false))
 				}),
 			),
 		),
@@ -477,7 +477,7 @@ func (l library) validateIPPrefix(p string, ver int64, strict bool) bool {
 	}
 }
 
-func (l library) validateUri(val string, checkAbs bool) bool {
+func (l library) validateURI(val string, checkAbs bool) bool {
 	uri, err := url.Parse(val)
 	if err != nil {
 		return false

--- a/cel/library.go
+++ b/cel/library.go
@@ -486,6 +486,8 @@ func (l library) validateURI(val string, checkAbs bool) bool {
 			return false
 		}
 	}
+
+	// Parse the query string to validate it is formed and encoded properly
 	_, err := url.ParseQuery(uri.RawQuery)
 	return err == nil
 }

--- a/cel/library.go
+++ b/cel/library.go
@@ -483,12 +483,11 @@ func (l library) validateURI(val string, checkAbs bool) bool {
 		return false
 	}
 	if checkAbs && !uri.IsAbs() {
-			return false
-		}
+		return false
 	}
 
 	// Parse the query string to validate it is formed and encoded properly
-	_, err := url.ParseQuery(uri.RawQuery)
+	_, err = url.ParseQuery(uri.RawQuery)
 	return err == nil
 }
 

--- a/cel/library.go
+++ b/cel/library.go
@@ -482,9 +482,7 @@ func (l library) validateURI(val string, checkAbs bool) bool {
 	if err != nil {
 		return false
 	}
-	if checkAbs {
-		ok := uri.IsAbs()
-		if !ok {
+	if checkAbs && !uri.IsAbs() {
 			return false
 		}
 	}


### PR DESCRIPTION
This adds an additional check for validating that the query string of a URI is correctly encoded.