### PR TITLE
Ignore all rules with IGNORE_ALWAYS

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -235,6 +235,11 @@ func (bldr *builder) buildValue(
 	valEval *value,
 	cache messageCache,
 ) (err error) {
+
+	if bldr.shouldSkip(constraints) {
+		return nil
+	}
+
 	steps := []func(
 		fdesc protoreflect.FieldDescriptor,
 		fieldConstraints *validate.FieldConstraints,
@@ -325,7 +330,6 @@ func (bldr *builder) processEmbeddedMessage(
 	cache messageCache,
 ) error {
 	if !isMessageField(fdesc) ||
-		bldr.shouldSkip(rules) ||
 		fdesc.IsMap() ||
 		(fdesc.IsList() && valEval.NestedRule == nil) {
 		return nil
@@ -352,7 +356,6 @@ func (bldr *builder) processWrapperConstraints(
 	cache messageCache,
 ) error {
 	if !isMessageField(fdesc) ||
-		bldr.shouldSkip(rules) ||
 		fdesc.IsMap() ||
 		(fdesc.IsList() && valEval.NestedRule == nil) {
 		return nil

--- a/builder.go
+++ b/builder.go
@@ -235,7 +235,6 @@ func (bldr *builder) buildValue(
 	valEval *value,
 	cache messageCache,
 ) (err error) {
-
 	if bldr.shouldSkip(constraints) {
 		return nil
 	}
@@ -325,7 +324,7 @@ func (bldr *builder) processFieldExpressions(
 
 func (bldr *builder) processEmbeddedMessage(
 	fdesc protoreflect.FieldDescriptor,
-	rules *validate.FieldConstraints,
+	_ *validate.FieldConstraints,
 	valEval *value,
 	cache messageCache,
 ) error {


### PR DESCRIPTION
With `FieldConstraints.ignore = IGNORE_ALWAYS`, the validation rules of a field will be skipped and not evaluated.

This will fix 86 conformance failures for the 140 test cases for `IGNORE_ALWAYS` added in https://github.com/bufbuild/protovalidate/pull/322.