### PR TITLE
Enhance `isEmail` validation

### DIFF
--- a/cel/library.go
+++ b/cel/library.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	// The regular expression to use when validating emails.
+	// See https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
 	emailRegex = "^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
 )
 

--- a/cel/library_test.go
+++ b/cel/library_test.go
@@ -15,7 +15,6 @@
 package cel
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/google/cel-go/cel"
@@ -27,9 +26,7 @@ import (
 func TestCELLib(t *testing.T) {
 	t.Parallel()
 
-	env, err := cel.NewEnv(cel.Lib(library{
-		emailRegex: regexp.MustCompile(emailRegex),
-	}))
+	env, err := cel.NewEnv(cel.Lib(NewLibrary()))
 	require.NoError(t, err)
 
 	t.Run("ext", func(t *testing.T) {

--- a/cel/library_test.go
+++ b/cel/library_test.go
@@ -15,6 +15,7 @@
 package cel
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/google/cel-go/cel"
@@ -26,7 +27,9 @@ import (
 func TestCELLib(t *testing.T) {
 	t.Parallel()
 
-	env, err := cel.NewEnv(cel.Lib(library{}))
+	env, err := cel.NewEnv(cel.Lib(library{
+		emailRegex: regexp.MustCompile(emailRegex),
+	}))
 	require.NoError(t, err)
 
 	t.Run("ext", func(t *testing.T) {

--- a/conformance/expected_failures.yaml
+++ b/conformance/expected_failures.yaml
@@ -1,9 +1,3 @@
-library/is_email:
-  - valid/label_all_digits
-  - valid/empty_atext
-  - valid/multiple_empty_atext
-  - invalid/non_ascii
-  - valid/exhaust_atext
 library/is_ip:
   - version/omitted/valid/ipv6_zone-id
   - version/omitted/valid/ipv6_zone-id_any_non_null_character


### PR DESCRIPTION
This enhances the current isEmail validation by using a consistent regex that will be used across protovalidate implementations.