### PR TITLE
Expose a `GlobalValidator` instance

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -29,6 +29,14 @@ import (
 var (
 	getGlobalValidator = sync.OnceValues(func() (Validator, error) { return New() })
 
+	// GlobalValidator provides access to the global Validator instance that is
+	// used by the [Validate] function. This is intended to be used by libraries
+	// that use protovalidate. This Validator can be used as a default when the
+	// user does not specify a Validator instance to use.
+	//
+	// Using the global Validator instance (either through [Validator] or via
+	// GlobalValidator) will result in lower memory usage than using multiple
+	// Validator instances, because each Validator instance has its own caches.
 	GlobalValidator Validator = globalValidator{}
 )
 

--- a/validator.go
+++ b/validator.go
@@ -26,11 +26,14 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-var getGlobalValidator = sync.OnceValues(func() (Validator, error) { return New() })
+var (
+	getGlobalValidator = sync.OnceValues(func() (Validator, error) { return New() })
+
+	GlobalValidator Validator = globalValidator{}
+)
 
 // Validator performs validation on any proto.Message values. The Validator is
 // safe for concurrent use.
-
 type Validator interface {
 	// Validate checks that message satisfies its constraints. Constraints are
 	// defined within the Protobuf file as options from the buf.validate
@@ -127,4 +130,10 @@ type validationConfig struct {
 	failFast bool
 	filter   Filter
 	nowFn    func() *timestamppb.Timestamp
+}
+
+type globalValidator struct{}
+
+func (globalValidator) Validate(msg proto.Message, options ...ValidationOption) error {
+	return Validate(msg, options...)
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -94,6 +94,37 @@ func TestValidator_ValidateGlobal(t *testing.T) {
 	})
 }
 
+func TestGlobalValidator(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HasMsgExprs", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			msg   *pb.HasMsgExprs
+			exErr bool
+		}{
+			{
+				&pb.HasMsgExprs{X: 2, Y: 43},
+				false,
+			},
+			{
+				&pb.HasMsgExprs{X: 9, Y: 8},
+				true,
+			},
+		}
+
+		for _, test := range tests {
+			err := GlobalValidator.Validate(test.msg)
+			if test.exErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		}
+	})
+}
+
 func TestRecursive(t *testing.T) {
 	t.Parallel()
 	val, err := New()


### PR DESCRIPTION
This allows libraries to default to using a global `Validator` instance. Internally, it is implemented by just forwarding through to the global `Validate` function, so it incurs the same exact performance penalty (e.g. a `sync.OnceValues`, essentially nothing), but the bonus is that libraries outside of protovalidate-go can easily default to it instead of constructing their own instances by default, allowing memory usage to be reduced when users do not construct their own protovalidate `Validator` instances.

I do not believe this has any serious downsides. Libraries should continue to allow users to explicitly pass protovalidate-go `Validator` instances if they want. Libraries which require an explicit `Validator` instance can now have `GlobalValidator` passed in to share memory with anything that uses the global Validator instance (either by using the `Validate` function directly, or by using `GlobalValidator` implicitly.)

Fixes #193.