### PR TITLE
Fix panic in isUri

### DIFF
--- a/cel/library.go
+++ b/cel/library.go
@@ -425,17 +425,20 @@ func (l library) uniqueBytes(list traits.Lister) ref.Val {
 	return types.Bool(true)
 }
 
-// isEmail returns true if addr is a valid email address.
+// isEmail reports whether val an email address, for example "foo@example.com".
 //
-// This regex conforms to the definition for a valid email address from the HTML standard.
+// Conforms to the definition for a valid email address from the HTML standard.
 // Note that this standard willfully deviates from RFC 5322, which allows many
 // unexpected forms of email addresses and will easily match a typographical
 // error.
-func isEmail(addr string) bool {
-	return emailRegex.MatchString(addr)
+func isEmail(val string) bool {
+	return emailRegex.MatchString(val)
 }
 
-// isURI validates whether val is a valid URI.
+// isURI reports whether val is a URI, for example "https://example.com/foo/bar?baz=quux#frag".
+//
+// URI is defined in the internet standard RFC 3986.
+// Zone Identifiers in IPv6 address literals are supported (RFC 6874).
 func isURI(val string) bool {
 	uri := &uri{
 		str: val,
@@ -443,7 +446,13 @@ func isURI(val string) bool {
 	return uri.uri()
 }
 
-// isURIRef validates whether val is a valid URI reference.
+// isURIRef reports whether val is a URI Reference - a URI such as
+// "https://example.com/foo/bar?baz=quux#frag", or a Relative Reference such as
+// "./foo/bar?query".
+//
+// URI, URI Reference, and Relative Reference are defined in the internet
+// standard RFC 3986. Zone Identifiers in IPv6 address literals are supported
+// (RFC 6874).
 func isURIRef(val string) bool {
 	uri := &uri{
 		str: val,
@@ -1282,7 +1291,7 @@ func (u *uri) checkHostPctEncoded(str string) bool {
 
 // host parses the rule:
 //
-//	host = IP-literal / IPv4address / reg-name.
+//	host = IP-literal / IPv4address / reg-name
 func (u *uri) host() bool {
 	if u.index >= len(u.str) {
 		return false

--- a/cel/library.go
+++ b/cel/library.go
@@ -1124,8 +1124,7 @@ func (u *uri) uriReference() bool {
 //		        / path-empty.
 func (u *uri) hierPart() bool {
 	start := u.index
-	if u.take('/') && //nolint:staticcheck
-		u.take('/') &&
+	if u.takeDoubleSlash() &&
 		u.authority() &&
 		u.pathAbempty() {
 		return true
@@ -1165,8 +1164,7 @@ func (u *uri) relativeRef() bool {
 //		          / path-empty
 func (u *uri) relativePart() bool {
 	start := u.index
-	if u.take('/') && //nolint:staticcheck
-		u.take('/') &&
+	if u.takeDoubleSlash() &&
 		u.authority() &&
 		u.pathAbempty() {
 		return true
@@ -1754,4 +1752,9 @@ func (u *uri) take(char byte) bool {
 		return true
 	}
 	return false
+}
+
+func (u *uri) takeDoubleSlash() bool {
+	first := u.take('/')
+	return first && u.take('/')
 }

--- a/cel/library.go
+++ b/cel/library.go
@@ -425,7 +425,7 @@ func (l library) uniqueBytes(list traits.Lister) ref.Val {
 	return types.Bool(true)
 }
 
-// isEmail reports whether val an email address, for example "foo@example.com".
+// isEmail reports whether val is an email address, for example "foo@example.com".
 //
 // Conforms to the definition for a valid email address from the HTML standard.
 // Note that this standard willfully deviates from RFC 5322, which allows many

--- a/cel/library.go
+++ b/cel/library.go
@@ -1186,7 +1186,7 @@ func (u *uri) scheme() bool {
 				break
 			}
 		}
-		if u.str[u.index] == ':' {
+		if u.peek(':') {
 			return true
 		}
 	}
@@ -1291,13 +1291,10 @@ func (u *uri) checkHostPctEncoded(str string) bool {
 //
 //	host = IP-literal / IPv4address / reg-name
 func (u *uri) host() bool {
-	if u.index >= len(u.str) {
-		return false
-	}
 	start := u.index
 	u.pctEncodedFound = false
 	// Note: IPv4address is a subset of reg-name
-	if (u.str[u.index] == '[' && u.ipLiteral()) || u.regName() {
+	if (u.peek('[') && u.ipLiteral()) || u.regName() {
 		if u.pctEncodedFound {
 			rawHost := u.str[start:u.index]
 			// RFC 3986:
@@ -1757,4 +1754,8 @@ func (u *uri) take(char byte) bool {
 func (u *uri) takeDoubleSlash() bool {
 	first := u.take('/')
 	return first && u.take('/')
+}
+
+func (u *uri) peek(char byte) bool {
+	return u.index < len(u.str) && u.str[u.index] == char
 }

--- a/cel/library_test.go
+++ b/cel/library_test.go
@@ -222,3 +222,8 @@ func buildTestProgram(t *testing.T, env *cel.Env, expr string) cel.Program {
 	require.NoError(t, err)
 	return prog
 }
+
+func TestIsUri(t *testing.T) {
+	t.Parallel()
+	require.True(t, isURI("A://"))
+}


### PR DESCRIPTION
https://github.com/bufbuild/protovalidate-go/pull/217/commits/ccafab4f2a95294b2d32dbb1c00df11edf51cecb improves the documentation, and https://github.com/bufbuild/protovalidate-go/pull/217/commits/e7c14c9b852bc86bf86546818d282c306b08b2b6 avoids a lint ignore. 

The panic is fixed in https://github.com/bufbuild/protovalidate-go/pull/217/commits/e7c14c9b852bc86bf86546818d282c306b08b2b6.