### PR TITLE
Fix improper handling of non-ascii characters in isHostname

### DIFF
--- a/cel/library.go
+++ b/cel/library.go
@@ -992,7 +992,7 @@ func isHostname(val string) bool {
 	}
 
 	allDigits := false
-	parts := strings.Split(strings.ToLower(str), ".")
+	parts := strings.Split(str, ".")
 
 	// split hostname on '.' and validate each part
 	for _, part := range parts {
@@ -1005,8 +1005,8 @@ func isHostname(val string) bool {
 		// for each character in part
 		for i := 0; i < len(part); i++ {
 			c := part[i]
-			// if the character is not a-z, 0-9, or '-', it is invalid
-			if (c < 'a' || c > 'z') && (c < '0' || c > '9') && c != '-' {
+			// if the character is not a-z, A-Z, 0-9, or '-', it is invalid
+			if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '-' {
 				return false
 			}
 			allDigits = allDigits && c >= '0' && c <= '9'

--- a/cel/library_test.go
+++ b/cel/library_test.go
@@ -222,3 +222,10 @@ func buildTestProgram(t *testing.T, env *cel.Env, expr string) cel.Program {
 	require.NoError(t, err)
 	return prog
 }
+
+func TestIsHostname(t *testing.T) {
+	t.Parallel()
+	require.True(t, isHostname("foo.example.com"))
+	require.True(t, isHostname("A.ISI.EDU"))
+	require.False(t, isHostname("İ"))
+}


### PR DESCRIPTION
`isHostname` falsely returns true for input "İ". This is a "Latin capital letter I with dot above", not to be confused with "I". 

This is a bug, because labels in hostnames can only contain alphanumeric characters a-z, A-Z, 0-9.

This fixes the bug by avoiding `strings.ToLower`, which converts "İ" to "i".