### PR TITLE
Fix isHostAndPort to reject leading zeros in port number

### DIFF
--- a/cel/library.go
+++ b/cel/library.go
@@ -1074,7 +1074,11 @@ func isPort(str string) bool {
 		}
 		return false
 	}
-	val, err := strconv.ParseInt(str, 0, 32)
+	if len(str) > 1 && str[0] == '0' {
+		// bad leading 0
+		return false
+	}
+	val, err := strconv.ParseUint(str, 0, 32)
 	if err != nil {
 		return false
 	}

--- a/cel/library_test.go
+++ b/cel/library_test.go
@@ -234,3 +234,9 @@ func TestIsHostname(t *testing.T) {
 	require.True(t, isHostname("A.ISI.EDU"))
 	require.False(t, isHostname("İ"))
 }
+
+func TestIsHostAndPort(t *testing.T) {
+	t.Parallel()
+	require.False(t, isHostAndPort("example.com:080", false))
+	require.False(t, isHostAndPort("example.com:00", false))
+}


### PR DESCRIPTION
While `isHostAndPort` rejects a port number with leading zero such as "080" as invalid, it doesn't reject "00".

This changes the behavior to consistently reject leading zeros.