### PR TITLE
Fix Ignore Always detection

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -213,14 +213,11 @@ func (bldr *builder) buildField(
 		Value: value{
 			Descriptor: fieldDescriptor,
 		},
-		Required:     fieldConstraints.GetRequired(),
-		IgnoreAlways: bldr.shouldIgnoreAlways(fieldConstraints),
-		IgnoreEmpty: fieldDescriptor.HasPresence() ||
-			bldr.shouldIgnoreEmpty(fieldConstraints),
-		IgnoreDefault: fieldDescriptor.HasPresence() &&
-			bldr.shouldIgnoreDefault(fieldConstraints),
+		HasPresence: fieldDescriptor.HasPresence(),
+		Required:    fieldConstraints.GetRequired(),
+		Ignore:      fieldConstraints.GetIgnore(),
 	}
-	if fld.IgnoreDefault {
+	if fld.shouldIgnoreDefault() {
 		fld.Zero = bldr.zeroValue(fieldDescriptor, false)
 	}
 	err := bldr.buildValue(fieldDescriptor, fieldConstraints, &fld.Value, cache)
@@ -511,10 +508,6 @@ func (bldr *builder) shouldIgnoreAlways(constraints *validate.FieldConstraints) 
 func (bldr *builder) shouldIgnoreEmpty(constraints *validate.FieldConstraints) bool {
 	return constraints.GetIgnore() == validate.Ignore_IGNORE_IF_UNPOPULATED ||
 		constraints.GetIgnore() == validate.Ignore_IGNORE_IF_DEFAULT_VALUE
-}
-
-func (bldr *builder) shouldIgnoreDefault(constraints *validate.FieldConstraints) bool {
-	return constraints.GetIgnore() == validate.Ignore_IGNORE_IF_DEFAULT_VALUE
 }
 
 func (bldr *builder) zeroValue(fdesc protoreflect.FieldDescriptor, forItems bool) protoreflect.Value {

--- a/builder.go
+++ b/builder.go
@@ -213,7 +213,8 @@ func (bldr *builder) buildField(
 		Value: value{
 			Descriptor: fieldDescriptor,
 		},
-		Required: fieldConstraints.GetRequired(),
+		Required:     fieldConstraints.GetRequired(),
+		IgnoreAlways: bldr.shouldIgnoreAlways(fieldConstraints),
 		IgnoreEmpty: fieldDescriptor.HasPresence() ||
 			bldr.shouldIgnoreEmpty(fieldConstraints),
 		IgnoreDefault: fieldDescriptor.HasPresence() &&
@@ -232,7 +233,7 @@ func (bldr *builder) buildValue(
 	valEval *value,
 	cache messageCache,
 ) (err error) {
-	if bldr.shouldSkip(constraints) {
+	if bldr.shouldIgnoreAlways(constraints) {
 		return nil
 	}
 
@@ -503,7 +504,7 @@ func (bldr *builder) processRepeatedConstraints(
 	return nil
 }
 
-func (bldr *builder) shouldSkip(constraints *validate.FieldConstraints) bool {
+func (bldr *builder) shouldIgnoreAlways(constraints *validate.FieldConstraints) bool {
 	return constraints.GetIgnore() == validate.Ignore_IGNORE_ALWAYS
 }
 

--- a/field.go
+++ b/field.go
@@ -37,6 +37,9 @@ type field struct {
 	Value value
 	// Required indicates that the field must have a set value.
 	Required bool
+	// IgnoreAlways indicates if a field should always skip validation.
+	// If true, this will take precedence and all checks are skipped.
+	IgnoreAlways bool
 	// IgnoreEmpty indicates if a field should skip validation on its zero value.
 	// This field is generally true for nullable fields or fields with the
 	// ignore_empty constraint explicitly set.
@@ -56,6 +59,9 @@ func (f field) Evaluate(_ protoreflect.Message, val protoreflect.Value, cfg *val
 }
 
 func (f field) EvaluateMessage(msg protoreflect.Message, cfg *validationConfig) (err error) {
+	if f.IgnoreAlways {
+		return nil
+	}
 	if !cfg.filter.ShouldValidate(msg, f.Value.Descriptor) {
 		return nil
 	}


### PR DESCRIPTION
This fixes a small bug in how an `IGNORE_ALWAYS` annotation is processed.

Previously, when `IGNORE_ALWAYS` was detected, the builder just skipped all the `processXXX` methods for a value. However, the field's `EvaluateMessage` was still being called and there was no check present to see if we should skip validation. Instead, it would continue evaluating and since there was no value present, it would fail validation.

This adds a new `IgnoreAlways` attribute on the `field` struct so that at evaluation time, we can determine whether everything should be skipped entirely. In addition, it renames `shouldSkip` to `shouldIgnoreAlways` for consistency.

Note: tested this against Protovalidate 0.10.4 and can confirm that all conformance tests pass.