### PR TITLE
Relax go version requirement in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bufbuild/protovalidate-go
 
-go 1.23.4
+go 1.23.0
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250307204501-0409229c3780.1


### PR DESCRIPTION
Update go.mod to relax version requirement to 1.23.0. There is nothing specific in later patch releases that is required by this library, so we should not require consumers to upgrade.