### PR TITLE
Fix IPv6 double colon parsing

### DIFF
--- a/cel/library.go
+++ b/cel/library.go
@@ -789,7 +789,10 @@ func (i *ipv6) addressPart() bool {
 		}
 		break
 	}
-	return i.doubleColonSeen || len(i.pieces) == 8
+	if i.doubleColonSeen {
+		return len(i.pieces) < 8
+	}
+	return len(i.pieces) == 8
 }
 
 // zoneID parses the rule from RFC 6874:


### PR DESCRIPTION
Fuzzing brought up an inconsistency: "0:0:0:0:0:0:0::0". This address has eight 16-bit pieces and a double colon. Since a double colon elides one or more 16-bit pieces, this is an invalid notation. 

Adding conformance tests in https://github.com/bufbuild/protovalidate/pull/350.