### PR TITLE
Uncomment previously failing tests

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -66,17 +66,16 @@ func TestCache_BuildStandardRules(t *testing.T) {
 			}}},
 			exCt: 1,
 		},
-		// TODO (steve) - Failing on v0.11.0
-		// {
-		// 	name: "list item rules",
-		// 	desc: getFieldDesc(t, &cases.RepeatedNone{}, "val"),
-		// 	cons: &validate.FieldRules{Type: &validate.FieldRules_Int64{Int64: &validate.Int64Rules{
-		// 		NotIn: []int64{123},
-		// 		Const: proto.Int64(456),
-		// 	}}},
-		// 	forItems: true,
-		// 	exCt:     2,
-		// },
+		{
+			name: "list item rules",
+			desc: getFieldDesc(t, &cases.RepeatedNone{}, "val"),
+			cons: &validate.FieldRules{Type: &validate.FieldRules_Int64{Int64: &validate.Int64Rules{
+				NotIn: []int64{123},
+				Const: proto.Int64(456),
+			}}},
+			forItems: true,
+			exCt:     2,
+		},
 		{
 			name: "map rules",
 			desc: getFieldDesc(t, &cases.MapNone{}, "val"),

--- a/validator_test.go
+++ b/validator_test.go
@@ -377,27 +377,26 @@ func TestValidator_Validate_Filter(t *testing.T) {
 		require.NotErrorAs(t, err, &valErr)
 	})
 
-	// TODO (steve) - Failing on v0.11.0
-	// t.Run("FilterExcludeCompilationError", func(t *testing.T) {
-	// 	t.Parallel()
-	// 	val, err := New()
-	// 	require.NoError(t, err)
-	// 	msg := &pb.MixedValidInvalidRules{
-	// 		ValidStringRule:     "bar",
-	// 		StringFieldBoolRule: "foo",
-	// 	}
-	// 	err = val.Validate(msg, WithFilter(FilterFunc(
-	// 		func(_ protoreflect.Message, d protoreflect.Descriptor) bool {
-	// 			return d == msg.ProtoReflect().Descriptor().Fields().Get(1)
-	// 		},
-	// 	)))
-	// 	require.Error(t, err)
-	// 	compErr := &CompilationError{}
-	// 	require.NotErrorAs(t, err, &compErr)
-	// 	valErr := &ValidationError{}
-	// 	require.ErrorAs(t, err, &valErr)
-	// 	require.Len(t, valErr.Violations, 1)
-	// })
+	t.Run("FilterExcludeCompilationError", func(t *testing.T) {
+		t.Parallel()
+		val, err := New()
+		require.NoError(t, err)
+		msg := &pb.MixedValidInvalidRules{
+			ValidStringRule:     "bar",
+			StringFieldBoolRule: "foo",
+		}
+		err = val.Validate(msg, WithFilter(FilterFunc(
+			func(_ protoreflect.Message, d protoreflect.Descriptor) bool {
+				return d == msg.ProtoReflect().Descriptor().Fields().Get(1)
+			},
+		)))
+		require.Error(t, err)
+		compErr := &CompilationError{}
+		require.NotErrorAs(t, err, &compErr)
+		valErr := &ValidationError{}
+		require.ErrorAs(t, err, &valErr)
+		require.Len(t, valErr.Violations, 1)
+	})
 }
 
 func TestValidator_ValidateCompilationError(t *testing.T) {


### PR DESCRIPTION
These tests were commented out when upgrading to v0.11.0 bc of the `getField` types bug. 

https://github.com/bufbuild/protovalidate-go/pull/229 fixed this issue, but the tests were never uncommented. 