### PR TITLE
Update to pv release candidate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GOLANGCI_LINT_VERSION ?= v2.1.2
 # Set to use a different version of protovalidate-conformance.
 # Should be kept in sync with the version referenced in buf.yaml and
 # 'buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go' in go.mod.
-CONFORMANCE_VERSION ?= v0.12.0
+CONFORMANCE_VERSION ?= v1.0.0-rc.1
 
 .PHONY: help
 help: ## Describe useful make targets

--- a/buf.yaml
+++ b/buf.yaml
@@ -2,8 +2,8 @@ version: v2
 modules:
   - path: proto
 deps:
-  - buf.build/bufbuild/protovalidate:v0.12.0
-  - buf.build/bufbuild/protovalidate-testing:v0.12.0
+  - buf.build/bufbuild/protovalidate:v1.0.0-rc.1
+  - buf.build/bufbuild/protovalidate-testing:v1.0.0-rc.1
 lint:
   use:
     - STANDARD

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module buf.build/go/protovalidate
 go 1.23.0
 
 require (
-	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250603165357-b52ab10f4468.1
+	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-00000000000000-c7344d9f5dae.1
 	github.com/google/cel-go v0.25.0
 	github.com/stretchr/testify v1.10.0
 	google.golang.org/protobuf v1.36.6

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250603165357-b52ab10f4468.1 h1:uwSqFkn8DDTzNlaV9TxgSXY5OCaNdb4rH+Axd2FujkE=
-buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250603165357-b52ab10f4468.1/go.mod h1:avRlCjnFzl98VPaeCtJ24RrV/wwHFzB8sWXhj26+n/U=
+buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-00000000000000-c7344d9f5dae.1 h1:nmsl+LeZt89FPjFhJvd0LTaUjmLy4MDAC+XEbzXc3xU=
+buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-00000000000000-c7344d9f5dae.1/go.mod h1:avRlCjnFzl98VPaeCtJ24RrV/wwHFzB8sWXhj26+n/U=
 cel.dev/expr v0.23.1 h1:K4KOtPCJQjVggkARsjG9RWXP6O4R73aHeJMa/dmCQQg=
 cel.dev/expr v0.23.1/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=


### PR DESCRIPTION
This updates the repo to the v1.0.0-rc.1 release candidate for Protovalidate.