### PR TITLE
Fix error message for too many selected fields with required MessageOneofRule

### DIFF
--- a/message_oneof.go
+++ b/message_oneof.go
@@ -55,21 +55,20 @@ func (o messageOneof) EvaluateMessage(msg protoreflect.Message, cfg *validationC
 				count++
 			}
 		}
-
-		if o.Required && count != 1 {
-			err.Violations = append(err.Violations, &Violation{
-				Proto: &validate.Violation{
-					RuleId:  proto.String("message.oneof"),
-					Message: proto.String(fmt.Sprintf("one of %s must be set", o.formatFields())),
-				},
-			})
-			return err
-		}
 		if count > 1 {
 			err.Violations = append(err.Violations, &Violation{
 				Proto: &validate.Violation{
 					RuleId:  proto.String("message.oneof"),
 					Message: proto.String(fmt.Sprintf("only one of %s can be set", o.formatFields())),
+				},
+			})
+			return err
+		}
+		if o.Required && count != 1 {
+			err.Violations = append(err.Violations, &Violation{
+				Proto: &validate.Violation{
+					RuleId:  proto.String("message.oneof"),
+					Message: proto.String(fmt.Sprintf("one of %s must be set", o.formatFields())),
 				},
 			})
 			return err


### PR DESCRIPTION
Here's the new oneof rule:

```proto
message Test {
  option (buf.validate.message).oneof = {
    fields: ["a", "b"],
  };
  bool a = 1;
  bool b = 2;
}
```

It validates that at most 1 field in the group is set. So with the input `&Test{A: true, B: true}`, it yields the error `only one of a, b can be set [message.oneof]`.

The rule can be configured to require that at least one field is set:

```diff
message Test {
  option (buf.validate.message).oneof = {
    fields: ["a", "b"],
+   required: true
  };
  bool a = 1;
  bool b = 2;
}
```

With the same input, the rule now yields the error `one of a, b must be set [message.oneof]`. This message sounds like a field is missing, but the issue is that too many fields are set.

With this PR, the error message for the second case reads `only one of a, b can be set [message.oneof]`, same as the first case.