### PR TITLE
Avoid allocation if there are no rules

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -254,11 +254,8 @@ func (bldr *builder) buildField(
 	msgRules *validate.MessageRules,
 	cache messageCache,
 ) (field, error) {
-	if !fieldRules.HasIgnore() && isPartOfMessageOneof(msgRules, fieldDescriptor) {
+	if fieldRules != nil && !fieldRules.HasIgnore() && isPartOfMessageOneof(msgRules, fieldDescriptor) {
 		fieldRules = proto.CloneOf(fieldRules)
-		if fieldRules == nil {
-			fieldRules = &validate.FieldRules{}
-		}
 		fieldRules.SetIgnore(validate.Ignore_IGNORE_IF_UNPOPULATED)
 	}
 	fld := field{


### PR DESCRIPTION
In a previous PR I always created the field rules to set the implicit ignore, but this is not needed if there are no rules to run. We can just skip setting if the rules are empty.