### PR TITLE
Revert to generate from CONFORMANCE_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ generate: generate-proto generate-license ## Regenerate code and license headers
 .PHONY: generate-proto
 generate-proto: $(BIN)/buf
 	rm -rf internal/gen/*/
-	$(BIN)/buf generate https://github.com/bufbuild/protovalidate.git#branch=next,subdir=proto/protovalidate-testing
+	$(BIN)/buf generate buf.build/bufbuild/protovalidate-testing:$(CONFORMANCE_VERSION)
 	$(BIN)/buf generate
 
 .PHONY: generate-license


### PR DESCRIPTION
The make target `generate-proto` was changed to generate from the upstream branch `next`. This reverts the change back to use the `CONFORMANCE_VERSION` variable.