### PR TITLE
Add ability to depend on arbitrary upstream commits

### DIFF
--- a/.github/workflows/check-gen-dep.yaml
+++ b/.github/workflows/check-gen-dep.yaml
@@ -1,0 +1,25 @@
+name: Check generated SDK dependency
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check gen dependency version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - name: Check for zeroed-out version
+        run: |
+          if grep -q 'buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go.*00000000000000' go.mod; then
+            echo "::error::buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go has a zeroed-out pseudo-version in go.mod. This happens when depending on a non-main version of protovalidate. Update PROTOVALIDATE_VERSION in the Makefile to a release or commit on the main branch of protovalidate and run 'make sync-upstream'."
+            exit 1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -15,17 +15,19 @@ LICENSE_IGNORE := -e internal/testdata/
 GO ?= go
 ARGS ?= --strict_message --strict_error
 GOLANGCI_LINT_VERSION ?= v2.9.0
-# Set to use a different version of protovalidate-conformance.
-# Should be kept in sync with the version referenced in buf.yaml and
-# 'buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go' in go.mod.
-CONFORMANCE_VERSION ?= v1.1.0
+# Set the protovalidate version, can be a commit, branch, or tag
+PROTOVALIDATE_VERSION ?= 8b6fa0a9cbff5b0e600f1d2a3024e135b5594db7
+PROTOVALIDATE_PROTO_VERSION := $(shell PATH="$(abspath $(BIN)):$(PATH)" ./make/scripts/resolve_bsr_commit.sh buf.build/bufbuild/protovalidate $(PROTOVALIDATE_VERSION))
+PROTOVALIDATE_TESTING_PROTO_VERSION := $(shell PATH="$(abspath $(BIN)):$(PATH)" ./make/scripts/resolve_bsr_commit.sh buf.build/bufbuild/protovalidate-testing $(PROTOVALIDATE_VERSION))
+PROTOBUF_GO_VERSION := $(shell go list -json -m google.golang.org/protobuf  | jq -r '.Version')
+PROTOVALIDATE_GEN_SDK_VERSION := $(shell buf registry sdk version --module=buf.build/bufbuild/protovalidate:$(PROTOVALIDATE_PROTO_VERSION) --plugin=buf.build/protocolbuffers/go:$(PROTOBUF_GO_VERSION)) 
 
 .PHONY: help
 help: ## Describe useful make targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "%-15s %s\n", $$1, $$2}'
 
 .PHONY: all
-all: generate test conformance lint ## Generate and run all tests and lint (default)
+all: sync-upstream generate test conformance lint ## Generate and run all tests and lint (default)
 
 .PHONY: clean
 clean: ## Delete intermediate build artifacts
@@ -72,8 +74,14 @@ generate: generate-proto generate-license ## Regenerate code and license headers
 .PHONY: generate-proto
 generate-proto: $(BIN)/buf
 	rm -rf internal/gen/*/
-	$(BIN)/buf generate buf.build/bufbuild/protovalidate-testing:$(CONFORMANCE_VERSION)
+	$(BIN)/buf generate buf.build/bufbuild/protovalidate-testing:$(PROTOVALIDATE_TESTING_PROTO_VERSION)
 	$(BIN)/buf generate
+
+.PHONY: sync-upstream
+sync-upstream:
+	yq -i '(.deps[] | select(. == "buf.build/bufbuild/protovalidate:*")) = "buf.build/bufbuild/protovalidate:$(PROTOVALIDATE_PROTO_VERSION)"' buf.yaml
+	buf dep update
+	go get buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go@$(PROTOVALIDATE_GEN_SDK_VERSION)
 
 .PHONY: generate-license
 generate-license: $(BIN)/license-header
@@ -132,7 +140,7 @@ $(BIN)/golangci-lint: $(BIN) Makefile
 
 $(BIN)/protovalidate-conformance: $(BIN) Makefile
 	GOBIN=$(abspath $(BIN)) $(GO) install \
-    	github.com/bufbuild/protovalidate/tools/protovalidate-conformance@$(CONFORMANCE_VERSION)
+    	github.com/bufbuild/protovalidate/tools/protovalidate-conformance@$(PROTOVALIDATE_VERSION)
 
 .PHONY: protovalidate-conformance-go
 protovalidate-conformance-go: $(BIN)

--- a/buf.lock
+++ b/buf.lock
@@ -2,8 +2,8 @@
 version: v2
 deps:
   - name: buf.build/bufbuild/protovalidate
-    commit: 2a1774d888024a9b93ce7eb4b59f6a83
-    digest: b5:6b7f9bc919b65e5b79d7b726ffc03d6f815a412d6b792970fa6f065cae162107bd0a9d47272c8ab1a2c9514e87b13d3fbf71df614374d62d2183afb64be2d30a
+    commit: 5dcec42a7ef94f16ac710abcd02271f7
+    digest: b5:ac3cd336344af698d3f81aafad90a360cbd650788f019677a65629d6032c8f50bb29530af67b6ffdac08f026fb4453a3674b8bdf229ba278e2fbfc22489dc024
   - name: buf.build/rodaine/protogofakeit
     commit: 9caf0fc578d3413590962a1764b81b94
     digest: b5:eeead7373f2f598ebc8f91aa3a68d6b50630076341d875b22dc6760126bc56c82cf1e98f5a2eff9815ba55fa48ab81745c93a5aeefd5e4697bf43c9ea4694735

--- a/buf.yaml
+++ b/buf.yaml
@@ -2,7 +2,8 @@ version: v2
 modules:
   - path: proto
 deps:
-  - buf.build/bufbuild/protovalidate:v1.1.0
+  # DO NOT EDIT. This is set via make.
+  - buf.build/bufbuild/protovalidate:5dcec42a7ef94f16ac710abcd02271f7
   - buf.build/rodaine/protogofakeit
 lint:
   use:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module buf.build/go/protovalidate
 go 1.24.0
 
 require (
-	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260209202127-80ab13bee0bf.1
+	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-00000000000000-5dcec42a7ef9.1
 	buf.build/go/hyperpb v0.1.3
 	github.com/brianvoe/gofakeit/v6 v6.28.0
 	github.com/google/cel-go v0.27.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 buf.build/gen/go/bufbuild/hyperpb-examples/protocolbuffers/go v1.36.7-20250725192734-0dd56aa9cbbc.1 h1:bFnppdLYActzr2F0iomSrkjUnGgVufb0DtZxjKgTLGc=
 buf.build/gen/go/bufbuild/hyperpb-examples/protocolbuffers/go v1.36.7-20250725192734-0dd56aa9cbbc.1/go.mod h1:x7jYNX5/7EPnsKHEq596krkOGzvR97/MsZw2fw3Mrq0=
-buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260209202127-80ab13bee0bf.1 h1:PMmTMyvHScV9Mn8wc6ASge9uRcHy0jtqPd+fM35LmsQ=
-buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260209202127-80ab13bee0bf.1/go.mod h1:tvtbpgaVXZX4g6Pn+AnzFycuRK3MOz5HJfEGeEllXYM=
+buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-00000000000000-5dcec42a7ef9.1 h1:yAgJbCjF8l3uAD3cBNJydUWYxEMa8q22BGofzt8IbiQ=
+buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-00000000000000-5dcec42a7ef9.1/go.mod h1:tvtbpgaVXZX4g6Pn+AnzFycuRK3MOz5HJfEGeEllXYM=
 buf.build/go/hyperpb v0.1.3 h1:wiw2F7POvAe2VA2kkB0TAsFwj91lXbFrKM41D3ZgU1w=
 buf.build/go/hyperpb v0.1.3/go.mod h1:IHXAM5qnS0/Fsnd7/HGDghFNvUET646WoHmq1FDZXIE=
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=

--- a/internal/gen/buf/validate/conformance/cases/predefined_rules_proto2.pb.go
+++ b/internal/gen/buf/validate/conformance/cases/predefined_rules_proto2.pb.go
@@ -3099,13 +3099,13 @@ const file_buf_validate_conformance_cases_predefined_rules_proto2_proto_rawDesc 
 	"\x16float.abs_range.proto2\x12\x1bfloat value is out of range\x1a\x1dthis >= -rule && this <= ruleR\x13floatAbsRangeProto2:\xae\x01\n" +
 	"\x17double_abs_range_proto2\x12\x19.buf.validate.DoubleRules\x18\x89\t \x01(\x01B[\xc2HX\n" +
 	"V\n" +
-	"\x17double.abs_range.proto2\x12\x1cdouble value is out of range\x1a\x1dthis >= -rule && this <= ruleR\x14doubleAbsRangeProto2:\xb6\x01\n" +
-	"\x13int32_abs_in_proto2\x12\x18.buf.validate.Int32Rules\x18\x89\t \x03(\x05Bl\xc2Hi\n" +
-	"g\n" +
-	"\x13int32.abs_in.proto2\x12'value must be in absolute value of list\x1a'this in rule || this in rule.map(n, -n)R\x10int32AbsInProto2:\xd3\x01\n" +
-	"\x13int64_abs_in_proto2\x12\x18.buf.validate.Int64Rules\x18\x89\t \x03(\v2\x1b.google.protobuf.Int64ValueBl\xc2Hi\n" +
-	"g\n" +
-	"\x13int64.abs_in.proto2\x12'value must be in absolute value of list\x1a'this in rule || this in rule.map(n, -n)R\x10int64AbsInProto2:\x8e\x01\n" +
+	"\x17double.abs_range.proto2\x12\x1cdouble value is out of range\x1a\x1dthis >= -rule && this <= ruleR\x14doubleAbsRangeProto2:\xb0\x01\n" +
+	"\x13int32_abs_in_proto2\x12\x18.buf.validate.Int32Rules\x18\x89\t \x03(\x05Bf\xc2Hc\n" +
+	"a\n" +
+	"\x13int32.abs_in.proto2\x12!must be in absolute value of list\x1a'this in rule || this in rule.map(n, -n)R\x10int32AbsInProto2:\xcd\x01\n" +
+	"\x13int64_abs_in_proto2\x12\x18.buf.validate.Int64Rules\x18\x89\t \x03(\v2\x1b.google.protobuf.Int64ValueBf\xc2Hc\n" +
+	"a\n" +
+	"\x13int64.abs_in.proto2\x12!must be in absolute value of list\x1a'this in rule || this in rule.map(n, -n)R\x10int64AbsInProto2:\x8e\x01\n" +
 	"\x12uint32_even_proto2\x12\x19.buf.validate.UInt32Rules\x18\x89\t \x01(\bBD\xc2HA\n" +
 	"?\n" +
 	"\x12uint32.even.proto2\x12\x18uint32 value is not even\x1a\x0fthis % 2u == 0uR\x10uint32EvenProto2:\x8e\x01\n" +

--- a/internal/gen/buf/validate/conformance/cases/predefined_rules_proto2_protoopaque.pb.go
+++ b/internal/gen/buf/validate/conformance/cases/predefined_rules_proto2_protoopaque.pb.go
@@ -3255,13 +3255,13 @@ const file_buf_validate_conformance_cases_predefined_rules_proto2_proto_rawDesc 
 	"\x16float.abs_range.proto2\x12\x1bfloat value is out of range\x1a\x1dthis >= -rule && this <= ruleR\x13floatAbsRangeProto2:\xae\x01\n" +
 	"\x17double_abs_range_proto2\x12\x19.buf.validate.DoubleRules\x18\x89\t \x01(\x01B[\xc2HX\n" +
 	"V\n" +
-	"\x17double.abs_range.proto2\x12\x1cdouble value is out of range\x1a\x1dthis >= -rule && this <= ruleR\x14doubleAbsRangeProto2:\xb6\x01\n" +
-	"\x13int32_abs_in_proto2\x12\x18.buf.validate.Int32Rules\x18\x89\t \x03(\x05Bl\xc2Hi\n" +
-	"g\n" +
-	"\x13int32.abs_in.proto2\x12'value must be in absolute value of list\x1a'this in rule || this in rule.map(n, -n)R\x10int32AbsInProto2:\xd3\x01\n" +
-	"\x13int64_abs_in_proto2\x12\x18.buf.validate.Int64Rules\x18\x89\t \x03(\v2\x1b.google.protobuf.Int64ValueBl\xc2Hi\n" +
-	"g\n" +
-	"\x13int64.abs_in.proto2\x12'value must be in absolute value of list\x1a'this in rule || this in rule.map(n, -n)R\x10int64AbsInProto2:\x8e\x01\n" +
+	"\x17double.abs_range.proto2\x12\x1cdouble value is out of range\x1a\x1dthis >= -rule && this <= ruleR\x14doubleAbsRangeProto2:\xb0\x01\n" +
+	"\x13int32_abs_in_proto2\x12\x18.buf.validate.Int32Rules\x18\x89\t \x03(\x05Bf\xc2Hc\n" +
+	"a\n" +
+	"\x13int32.abs_in.proto2\x12!must be in absolute value of list\x1a'this in rule || this in rule.map(n, -n)R\x10int32AbsInProto2:\xcd\x01\n" +
+	"\x13int64_abs_in_proto2\x12\x18.buf.validate.Int64Rules\x18\x89\t \x03(\v2\x1b.google.protobuf.Int64ValueBf\xc2Hc\n" +
+	"a\n" +
+	"\x13int64.abs_in.proto2\x12!must be in absolute value of list\x1a'this in rule || this in rule.map(n, -n)R\x10int64AbsInProto2:\x8e\x01\n" +
 	"\x12uint32_even_proto2\x12\x19.buf.validate.UInt32Rules\x18\x89\t \x01(\bBD\xc2HA\n" +
 	"?\n" +
 	"\x12uint32.even.proto2\x12\x18uint32 value is not even\x1a\x0fthis % 2u == 0uR\x10uint32EvenProto2:\x8e\x01\n" +

--- a/internal/gen/buf/validate/conformance/cases/predefined_rules_proto_editions.pb.go
+++ b/internal/gen/buf/validate/conformance/cases/predefined_rules_proto_editions.pb.go
@@ -3177,13 +3177,13 @@ const file_buf_validate_conformance_cases_predefined_rules_proto_editions_proto_
 	"\x1cfloat.abs_range.edition_2023\x12\x1bfloat value is out of range\x1a\x1dthis >= -rule && this <= ruleR\x18floatAbsRangeEdition2023:\xbf\x01\n" +
 	"\x1ddouble_abs_range_edition_2023\x12\x19.buf.validate.DoubleRules\x18\x8a\t \x01(\x01Ba\xc2H^\n" +
 	"\\\n" +
-	"\x1ddouble.abs_range.edition_2023\x12\x1cdouble value is out of range\x1a\x1dthis >= -rule && this <= ruleR\x19doubleAbsRangeEdition2023:\xc7\x01\n" +
-	"\x19int32_abs_in_edition_2023\x12\x18.buf.validate.Int32Rules\x18\x8a\t \x03(\x05Br\xc2Ho\n" +
-	"m\n" +
-	"\x19int32.abs_in.edition_2023\x12'value must be in absolute value of list\x1a'this in rule || this in rule.map(n, -n)R\x15int32AbsInEdition2023:\xe4\x01\n" +
-	"\x19int64_abs_in_edition_2023\x12\x18.buf.validate.Int64Rules\x18\x8a\t \x03(\v2\x1b.google.protobuf.Int64ValueBr\xc2Ho\n" +
-	"m\n" +
-	"\x19int64.abs_in.edition_2023\x12'value must be in absolute value of list\x1a'this in rule || this in rule.map(n, -n)R\x15int64AbsInEdition2023:\x9f\x01\n" +
+	"\x1ddouble.abs_range.edition_2023\x12\x1cdouble value is out of range\x1a\x1dthis >= -rule && this <= ruleR\x19doubleAbsRangeEdition2023:\xc1\x01\n" +
+	"\x19int32_abs_in_edition_2023\x12\x18.buf.validate.Int32Rules\x18\x8a\t \x03(\x05Bl\xc2Hi\n" +
+	"g\n" +
+	"\x19int32.abs_in.edition_2023\x12!must be in absolute value of list\x1a'this in rule || this in rule.map(n, -n)R\x15int32AbsInEdition2023:\xde\x01\n" +
+	"\x19int64_abs_in_edition_2023\x12\x18.buf.validate.Int64Rules\x18\x8a\t \x03(\v2\x1b.google.protobuf.Int64ValueBl\xc2Hi\n" +
+	"g\n" +
+	"\x19int64.abs_in.edition_2023\x12!must be in absolute value of list\x1a'this in rule || this in rule.map(n, -n)R\x15int64AbsInEdition2023:\x9f\x01\n" +
 	"\x18uint32_even_edition_2023\x12\x19.buf.validate.UInt32Rules\x18\x8a\t \x01(\bBJ\xc2HG\n" +
 	"E\n" +
 	"\x18uint32.even.edition_2023\x12\x18uint32 value is not even\x1a\x0fthis % 2u == 0uR\x15uint32EvenEdition2023:\x9f\x01\n" +

--- a/internal/gen/buf/validate/conformance/cases/predefined_rules_proto_editions_protoopaque.pb.go
+++ b/internal/gen/buf/validate/conformance/cases/predefined_rules_proto_editions_protoopaque.pb.go
@@ -3333,13 +3333,13 @@ const file_buf_validate_conformance_cases_predefined_rules_proto_editions_proto_
 	"\x1cfloat.abs_range.edition_2023\x12\x1bfloat value is out of range\x1a\x1dthis >= -rule && this <= ruleR\x18floatAbsRangeEdition2023:\xbf\x01\n" +
 	"\x1ddouble_abs_range_edition_2023\x12\x19.buf.validate.DoubleRules\x18\x8a\t \x01(\x01Ba\xc2H^\n" +
 	"\\\n" +
-	"\x1ddouble.abs_range.edition_2023\x12\x1cdouble value is out of range\x1a\x1dthis >= -rule && this <= ruleR\x19doubleAbsRangeEdition2023:\xc7\x01\n" +
-	"\x19int32_abs_in_edition_2023\x12\x18.buf.validate.Int32Rules\x18\x8a\t \x03(\x05Br\xc2Ho\n" +
-	"m\n" +
-	"\x19int32.abs_in.edition_2023\x12'value must be in absolute value of list\x1a'this in rule || this in rule.map(n, -n)R\x15int32AbsInEdition2023:\xe4\x01\n" +
-	"\x19int64_abs_in_edition_2023\x12\x18.buf.validate.Int64Rules\x18\x8a\t \x03(\v2\x1b.google.protobuf.Int64ValueBr\xc2Ho\n" +
-	"m\n" +
-	"\x19int64.abs_in.edition_2023\x12'value must be in absolute value of list\x1a'this in rule || this in rule.map(n, -n)R\x15int64AbsInEdition2023:\x9f\x01\n" +
+	"\x1ddouble.abs_range.edition_2023\x12\x1cdouble value is out of range\x1a\x1dthis >= -rule && this <= ruleR\x19doubleAbsRangeEdition2023:\xc1\x01\n" +
+	"\x19int32_abs_in_edition_2023\x12\x18.buf.validate.Int32Rules\x18\x8a\t \x03(\x05Bl\xc2Hi\n" +
+	"g\n" +
+	"\x19int32.abs_in.edition_2023\x12!must be in absolute value of list\x1a'this in rule || this in rule.map(n, -n)R\x15int32AbsInEdition2023:\xde\x01\n" +
+	"\x19int64_abs_in_edition_2023\x12\x18.buf.validate.Int64Rules\x18\x8a\t \x03(\v2\x1b.google.protobuf.Int64ValueBl\xc2Hi\n" +
+	"g\n" +
+	"\x19int64.abs_in.edition_2023\x12!must be in absolute value of list\x1a'this in rule || this in rule.map(n, -n)R\x15int64AbsInEdition2023:\x9f\x01\n" +
 	"\x18uint32_even_edition_2023\x12\x19.buf.validate.UInt32Rules\x18\x8a\t \x01(\bBJ\xc2HG\n" +
 	"E\n" +
 	"\x18uint32.even.edition_2023\x12\x18uint32 value is not even\x1a\x0fthis % 2u == 0uR\x15uint32EvenEdition2023:\x9f\x01\n" +

--- a/internal/gen/buf/validate/conformance/cases/strings.pb.go
+++ b/internal/gen/buf/validate/conformance/cases/strings.pb.go
@@ -3704,6 +3704,120 @@ func (b0 StringHostAndOptionalPort_builder) Build() *StringHostAndOptionalPort {
 	return m0
 }
 
+type StringProtobufFQN struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	Val           string                 `protobuf:"bytes,1,opt,name=val,proto3" json:"val,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StringProtobufFQN) Reset() {
+	*x = StringProtobufFQN{}
+	mi := &file_buf_validate_conformance_cases_strings_proto_msgTypes[63]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StringProtobufFQN) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StringProtobufFQN) ProtoMessage() {}
+
+func (x *StringProtobufFQN) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_strings_proto_msgTypes[63]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *StringProtobufFQN) GetVal() string {
+	if x != nil {
+		return x.Val
+	}
+	return ""
+}
+
+func (x *StringProtobufFQN) SetVal(v string) {
+	x.Val = v
+}
+
+type StringProtobufFQN_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Val string
+}
+
+func (b0 StringProtobufFQN_builder) Build() *StringProtobufFQN {
+	m0 := &StringProtobufFQN{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Val = b.Val
+	return m0
+}
+
+type StringProtobufDotFQN struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	Val           string                 `protobuf:"bytes,1,opt,name=val,proto3" json:"val,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StringProtobufDotFQN) Reset() {
+	*x = StringProtobufDotFQN{}
+	mi := &file_buf_validate_conformance_cases_strings_proto_msgTypes[64]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StringProtobufDotFQN) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StringProtobufDotFQN) ProtoMessage() {}
+
+func (x *StringProtobufDotFQN) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_strings_proto_msgTypes[64]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *StringProtobufDotFQN) GetVal() string {
+	if x != nil {
+		return x.Val
+	}
+	return ""
+}
+
+func (x *StringProtobufDotFQN) SetVal(v string) {
+	x.Val = v
+}
+
+type StringProtobufDotFQN_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Val string
+}
+
+func (b0 StringProtobufDotFQN_builder) Build() *StringProtobufDotFQN {
+	m0 := &StringProtobufDotFQN{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Val = b.Val
+	return m0
+}
+
 type StringExample struct {
 	state         protoimpl.MessageState `protogen:"hybrid.v1"`
 	Val           string                 `protobuf:"bytes,1,opt,name=val,proto3" json:"val,omitempty"`
@@ -3713,7 +3827,7 @@ type StringExample struct {
 
 func (x *StringExample) Reset() {
 	*x = StringExample{}
-	mi := &file_buf_validate_conformance_cases_strings_proto_msgTypes[63]
+	mi := &file_buf_validate_conformance_cases_strings_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3725,7 +3839,7 @@ func (x *StringExample) String() string {
 func (*StringExample) ProtoMessage() {}
 
 func (x *StringExample) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_strings_proto_msgTypes[63]
+	mi := &file_buf_validate_conformance_cases_strings_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3905,12 +4019,16 @@ const file_buf_validate_conformance_cases_strings_proto_rawDesc = "" +
 	"\x03val\x18\x01 \x01(\tB\b\xbaH\x05r\x03\x80\x02\x01R\x03val\"\xa4\x01\n" +
 	"\x19StringHostAndOptionalPort\x12\x86\x01\n" +
 	"\x03val\x18\x01 \x01(\tBt\xbaHq\xba\x01n\n" +
-	"\"string.host_and_port.optional_port\x12-value must be a host and (optional) port pair\x1a\x19this.isHostAndPort(false)R\x03val\".\n" +
+	"\"string.host_and_port.optional_port\x12-value must be a host and (optional) port pair\x1a\x19this.isHostAndPort(false)R\x03val\"/\n" +
+	"\x11StringProtobufFQN\x12\x1a\n" +
+	"\x03val\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xa8\x02\x01R\x03val\"2\n" +
+	"\x14StringProtobufDotFQN\x12\x1a\n" +
+	"\x03val\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x02\x01R\x03val\".\n" +
 	"\rStringExample\x12\x1d\n" +
 	"\x03val\x18\x01 \x01(\tB\v\xbaH\br\x06\x92\x02\x03fooR\x03valB\x96\x02\n" +
 	"\"com.buf.validate.conformance.casesB\fStringsProtoP\x01ZFbuf.build/go/protovalidate/internal/gen/buf/validate/conformance/cases\xa2\x02\x04BVCC\xaa\x02\x1eBuf.Validate.Conformance.Cases\xca\x02\x1eBuf\\Validate\\Conformance\\Cases\xe2\x02*Buf\\Validate\\Conformance\\Cases\\GPBMetadata\xea\x02!Buf::Validate::Conformance::Casesb\x06proto3"
 
-var file_buf_validate_conformance_cases_strings_proto_msgTypes = make([]protoimpl.MessageInfo, 64)
+var file_buf_validate_conformance_cases_strings_proto_msgTypes = make([]protoimpl.MessageInfo, 66)
 var file_buf_validate_conformance_cases_strings_proto_goTypes = []any{
 	(*StringNone)(nil),                 // 0: buf.validate.conformance.cases.StringNone
 	(*StringConst)(nil),                // 1: buf.validate.conformance.cases.StringConst
@@ -3975,7 +4093,9 @@ var file_buf_validate_conformance_cases_strings_proto_goTypes = []any{
 	(*StringInOneof)(nil),              // 60: buf.validate.conformance.cases.StringInOneof
 	(*StringHostAndPort)(nil),          // 61: buf.validate.conformance.cases.StringHostAndPort
 	(*StringHostAndOptionalPort)(nil),  // 62: buf.validate.conformance.cases.StringHostAndOptionalPort
-	(*StringExample)(nil),              // 63: buf.validate.conformance.cases.StringExample
+	(*StringProtobufFQN)(nil),          // 63: buf.validate.conformance.cases.StringProtobufFQN
+	(*StringProtobufDotFQN)(nil),       // 64: buf.validate.conformance.cases.StringProtobufDotFQN
+	(*StringExample)(nil),              // 65: buf.validate.conformance.cases.StringExample
 }
 var file_buf_validate_conformance_cases_strings_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
@@ -3999,7 +4119,7 @@ func file_buf_validate_conformance_cases_strings_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_buf_validate_conformance_cases_strings_proto_rawDesc), len(file_buf_validate_conformance_cases_strings_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   64,
+			NumMessages:   66,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/internal/gen/buf/validate/conformance/cases/strings_protoopaque.pb.go
+++ b/internal/gen/buf/validate/conformance/cases/strings_protoopaque.pb.go
@@ -3694,6 +3694,120 @@ func (b0 StringHostAndOptionalPort_builder) Build() *StringHostAndOptionalPort {
 	return m0
 }
 
+type StringProtobufFQN struct {
+	state          protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Val string                 `protobuf:"bytes,1,opt,name=val,proto3"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *StringProtobufFQN) Reset() {
+	*x = StringProtobufFQN{}
+	mi := &file_buf_validate_conformance_cases_strings_proto_msgTypes[63]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StringProtobufFQN) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StringProtobufFQN) ProtoMessage() {}
+
+func (x *StringProtobufFQN) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_strings_proto_msgTypes[63]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *StringProtobufFQN) GetVal() string {
+	if x != nil {
+		return x.xxx_hidden_Val
+	}
+	return ""
+}
+
+func (x *StringProtobufFQN) SetVal(v string) {
+	x.xxx_hidden_Val = v
+}
+
+type StringProtobufFQN_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Val string
+}
+
+func (b0 StringProtobufFQN_builder) Build() *StringProtobufFQN {
+	m0 := &StringProtobufFQN{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Val = b.Val
+	return m0
+}
+
+type StringProtobufDotFQN struct {
+	state          protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Val string                 `protobuf:"bytes,1,opt,name=val,proto3"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *StringProtobufDotFQN) Reset() {
+	*x = StringProtobufDotFQN{}
+	mi := &file_buf_validate_conformance_cases_strings_proto_msgTypes[64]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StringProtobufDotFQN) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StringProtobufDotFQN) ProtoMessage() {}
+
+func (x *StringProtobufDotFQN) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_strings_proto_msgTypes[64]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *StringProtobufDotFQN) GetVal() string {
+	if x != nil {
+		return x.xxx_hidden_Val
+	}
+	return ""
+}
+
+func (x *StringProtobufDotFQN) SetVal(v string) {
+	x.xxx_hidden_Val = v
+}
+
+type StringProtobufDotFQN_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Val string
+}
+
+func (b0 StringProtobufDotFQN_builder) Build() *StringProtobufDotFQN {
+	m0 := &StringProtobufDotFQN{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Val = b.Val
+	return m0
+}
+
 type StringExample struct {
 	state          protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_Val string                 `protobuf:"bytes,1,opt,name=val,proto3"`
@@ -3703,7 +3817,7 @@ type StringExample struct {
 
 func (x *StringExample) Reset() {
 	*x = StringExample{}
-	mi := &file_buf_validate_conformance_cases_strings_proto_msgTypes[63]
+	mi := &file_buf_validate_conformance_cases_strings_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3715,7 +3829,7 @@ func (x *StringExample) String() string {
 func (*StringExample) ProtoMessage() {}
 
 func (x *StringExample) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_strings_proto_msgTypes[63]
+	mi := &file_buf_validate_conformance_cases_strings_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3895,12 +4009,16 @@ const file_buf_validate_conformance_cases_strings_proto_rawDesc = "" +
 	"\x03val\x18\x01 \x01(\tB\b\xbaH\x05r\x03\x80\x02\x01R\x03val\"\xa4\x01\n" +
 	"\x19StringHostAndOptionalPort\x12\x86\x01\n" +
 	"\x03val\x18\x01 \x01(\tBt\xbaHq\xba\x01n\n" +
-	"\"string.host_and_port.optional_port\x12-value must be a host and (optional) port pair\x1a\x19this.isHostAndPort(false)R\x03val\".\n" +
+	"\"string.host_and_port.optional_port\x12-value must be a host and (optional) port pair\x1a\x19this.isHostAndPort(false)R\x03val\"/\n" +
+	"\x11StringProtobufFQN\x12\x1a\n" +
+	"\x03val\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xa8\x02\x01R\x03val\"2\n" +
+	"\x14StringProtobufDotFQN\x12\x1a\n" +
+	"\x03val\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x02\x01R\x03val\".\n" +
 	"\rStringExample\x12\x1d\n" +
 	"\x03val\x18\x01 \x01(\tB\v\xbaH\br\x06\x92\x02\x03fooR\x03valB\x96\x02\n" +
 	"\"com.buf.validate.conformance.casesB\fStringsProtoP\x01ZFbuf.build/go/protovalidate/internal/gen/buf/validate/conformance/cases\xa2\x02\x04BVCC\xaa\x02\x1eBuf.Validate.Conformance.Cases\xca\x02\x1eBuf\\Validate\\Conformance\\Cases\xe2\x02*Buf\\Validate\\Conformance\\Cases\\GPBMetadata\xea\x02!Buf::Validate::Conformance::Casesb\x06proto3"
 
-var file_buf_validate_conformance_cases_strings_proto_msgTypes = make([]protoimpl.MessageInfo, 64)
+var file_buf_validate_conformance_cases_strings_proto_msgTypes = make([]protoimpl.MessageInfo, 66)
 var file_buf_validate_conformance_cases_strings_proto_goTypes = []any{
 	(*StringNone)(nil),                 // 0: buf.validate.conformance.cases.StringNone
 	(*StringConst)(nil),                // 1: buf.validate.conformance.cases.StringConst
@@ -3965,7 +4083,9 @@ var file_buf_validate_conformance_cases_strings_proto_goTypes = []any{
 	(*StringInOneof)(nil),              // 60: buf.validate.conformance.cases.StringInOneof
 	(*StringHostAndPort)(nil),          // 61: buf.validate.conformance.cases.StringHostAndPort
 	(*StringHostAndOptionalPort)(nil),  // 62: buf.validate.conformance.cases.StringHostAndOptionalPort
-	(*StringExample)(nil),              // 63: buf.validate.conformance.cases.StringExample
+	(*StringProtobufFQN)(nil),          // 63: buf.validate.conformance.cases.StringProtobufFQN
+	(*StringProtobufDotFQN)(nil),       // 64: buf.validate.conformance.cases.StringProtobufDotFQN
+	(*StringExample)(nil),              // 65: buf.validate.conformance.cases.StringExample
 }
 var file_buf_validate_conformance_cases_strings_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
@@ -3989,7 +4109,7 @@ func file_buf_validate_conformance_cases_strings_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_buf_validate_conformance_cases_strings_proto_rawDesc), len(file_buf_validate_conformance_cases_strings_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   64,
+			NumMessages:   66,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/make/scripts/resolve_bsr_commit.sh
+++ b/make/scripts/resolve_bsr_commit.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# resolve_bsr_commit resolves a git ref (semver tag, branch, or commit
+# hash) to a BSR module commit name.
+#
+# Usage: resolve_bsr_commit.sh <module> <ref>
+#
+# Examples:
+#   resolve_bsr_commit.sh buf.build/bufbuild/protovalidate v1.1.0
+#   resolve_bsr_commit.sh buf.build/bufbuild/protovalidate main
+#   resolve_bsr_commit.sh buf.build/bufbuild/protovalidate 895eefca6d13
+
+MODULE="${1}"
+REF="${2}"
+
+# If the ref is a valid semver, return it directly.
+if echo "${REF}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+  echo "${REF}"
+  exit 0
+fi
+
+# Try to resolve the ref directly as a BSR label.
+if buf registry module commit resolve "${MODULE}:${REF}" --format json >/dev/null 2>&1; then
+  echo "${REF}"
+  exit 0
+fi
+
+# Fall back to searching commits by source_control_url suffix.
+PAGE_TOKEN=""
+while true; do
+  PAGE_ARGS=()
+  if [[ -n "${PAGE_TOKEN}" ]]; then
+    PAGE_ARGS=(--page-token="${PAGE_TOKEN}")
+  fi
+
+  RESULT="$(buf registry module commit list "${MODULE}" --format json --page-size 100 "${PAGE_ARGS[@]+"${PAGE_ARGS[@]}"}")"
+
+  FOUND="$(echo "${RESULT}" | jq -r --arg ref "${REF}" \
+    '.commits[] | select(.source_control_url != null) | select(.source_control_url | endswith($ref)) | .commit')"
+
+  if [[ -n "${FOUND}" ]]; then
+    echo "${FOUND}"
+    exit 0
+  fi
+
+  PAGE_TOKEN="$(echo "${RESULT}" | jq -r '.next_page // empty')"
+  if [[ -z "${PAGE_TOKEN}" ]]; then
+    echo "error: could not resolve ref '${REF}' for module '${MODULE}'" >&2
+    exit 1
+  fi
+done

--- a/validator_example_test.go
+++ b/validator_example_test.go
@@ -45,7 +45,7 @@ func Example() {
 
 	// output:
 	// valid: <nil>
-	// invalid: validation error: email: value must be a valid email address
+	// invalid: validation error: email: must be a valid email address
 }
 
 func ExampleWithFailFast() {
@@ -67,9 +67,9 @@ func ExampleWithFailFast() {
 
 	// output:
 	// default: validation errors:
-	//  - lat: value must be greater than or equal to -90 and less than or equal to 90
-	//  - lng: value must be greater than or equal to -180 and less than or equal to 180
-	// fail fast: validation error: lat: value must be greater than or equal to -90 and less than or equal to 90
+	//  - lat: must be greater than or equal to -90 and less than or equal to 90
+	//  - lng: must be greater than or equal to -180 and less than or equal to 180
+	// fail fast: validation error: lat: must be greater than or equal to -90 and less than or equal to 90
 }
 
 func ExampleWithMessages() {


### PR DESCRIPTION
With https://github.com/bufbuild/protovalidate/pull/470, all commits of protovalidate and protovalidate-testing module will be available on the BSR. This means we can depend on the generated SDK versions of those commits. 

This PR adds the ability to depend on an arbitrary upstream commit. This drastically improves the development cycle by letting us review and merge PRs for each individual change in `validate.proto`, rather than bundling all changes from the previous release into a single PR.

It uses the git commit/tag/branch as the pointer because there are two different BSR modules, and each will have its own BSR commit name. 

To avoid merging zeroed versions of the generated SDK, this ensures that only release versions or commits on the main version can be merged. The CI failure is because of this. Once https://github.com/bufbuild/protovalidate/pull/470 is merged and we update the reference here, it should pass. 

Because of the version update, there were some errors in the example test. I fixed them in a separate commit.