### PR TITLE
Pin buf version to `1.67.0`

### DIFF
--- a/.github/workflows/buf.yaml
+++ b/.github/workflows/buf.yaml
@@ -31,5 +31,6 @@ jobs:
           push: false
           archive: false
           breaking: false
+          version: "1.67.0"
       - name: Check Generate
         run: make checkgenerate

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ $(BIN):
 	@mkdir -p $(BIN)
 
 $(BIN)/buf: $(BIN) Makefile
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/bufbuild/buf/cmd/buf@latest
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/bufbuild/buf/cmd/buf@v1.67.0
 
 $(BIN)/license-header: $(BIN) Makefile
 	GOBIN=$(abspath $(@D)) $(GO) install \


### PR DESCRIPTION
Version `1.2.0` results in an error with the latest version of buf. This pins buf version to `1.67.0` to unblock bumping to protovalidate to `1.2.0`.