### PR TITLE
Fix error message for string.not_contains in native rules

### DIFF
--- a/native_string.go
+++ b/native_string.go
@@ -450,7 +450,7 @@ func (n nativeStringEval) Evaluate(_ protoreflect.Message, val protoreflect.Valu
 
 	if n.notContains != nil && strings.Contains(strVal, *n.notContains) {
 		violations = append(violations, n.newViolation(strDescs.notContainsSite,
-			"string.not_contains", fmt.Sprintf("value contains substring `%s`", *n.notContains),
+			"string.not_contains", fmt.Sprintf("contains substring `%s`", *n.notContains),
 			val, protoreflect.ValueOfString(*n.notContains)))
 		if cfg.failFast {
 			return &ValidationError{Violations: violations[:1]}


### PR DESCRIPTION
The message for string.not_contains still had the word 'value' in the native rules. New (unreleased) conformance tests discovered the problem.