### PR TITLE
Improve formatting, NaN handling, and header validation

### DIFF
--- a/native_numeric.go
+++ b/native_numeric.go
@@ -133,17 +133,25 @@ func tryBuildNativeNumericRules[T numericValue, R numericRules[T]](
 
 	hasRule := false
 
+	// bail out if there's a gt/lt and the value is NaN
+	// (it's an invalid protovalidate rule; let CEL return the error)
 	var lowerValue T
 	lower := lowerBoundNone
 	switch {
 	case rules.HasGt():
 		lower = lowerBoundGt
 		lowerValue = rules.GetGt()
+		if math.IsNaN(float64(lowerValue)) {
+			return nil
+		}
 		rules.ProtoReflect().Clear(config.descs.gtSite.desc)
 		hasRule = true
 	case rules.HasGte():
 		lower = lowerBoundGte
 		lowerValue = rules.GetGte()
+		if math.IsNaN(float64(lowerValue)) {
+			return nil
+		}
 		rules.ProtoReflect().Clear(config.descs.gteSite.desc)
 		hasRule = true
 	}
@@ -154,11 +162,17 @@ func tryBuildNativeNumericRules[T numericValue, R numericRules[T]](
 	case rules.HasLt():
 		upper = upperBoundLt
 		upperValue = rules.GetLt()
+		if math.IsNaN(float64(upperValue)) {
+			return nil
+		}
 		rules.ProtoReflect().Clear(config.descs.ltSite.desc)
 		hasRule = true
 	case rules.HasLte():
 		upper = upperBoundLte
 		upperValue = rules.GetLte()
+		if math.IsNaN(float64(upperValue)) {
+			return nil
+		}
 		rules.ProtoReflect().Clear(config.descs.lteSite.desc)
 		hasRule = true
 	}

--- a/native_numeric.go
+++ b/native_numeric.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 	"slices"
+	"strconv"
 	"strings"
 
 	"buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go/buf/validate"
@@ -470,16 +471,16 @@ func (n nativeNumericCompare[T]) gtltRule() string {
 
 func (n nativeNumericCompare[T]) loMessage() string {
 	if n.lower == lowerBoundGt {
-		return fmt.Sprintf("greater than %v", n.lo)
+		return "greater than " + format(n.lo)
 	}
-	return fmt.Sprintf("greater than or equal to %v", n.lo)
+	return "greater than or equal to " + format(n.lo)
 }
 
 func (n nativeNumericCompare[T]) hiMessage() string {
 	if n.upper == upperBoundLt {
-		return fmt.Sprintf("less than %v", n.hi)
+		return "less than " + format(n.hi)
 	}
-	return fmt.Sprintf("less than or equal to %v", n.hi)
+	return "less than or equal to " + format(n.hi)
 }
 
 func (n nativeNumericCompare[T]) conjunction() string {
@@ -496,7 +497,7 @@ func (n nativeNumericCompare[T]) Evaluate(_ protoreflect.Message, val protorefle
 	if n.constVal != nil && valT != *n.constVal {
 		violations = append(violations, n.newViolation(n.config.descs.constSite,
 			n.config.typeName+".const",
-			fmt.Sprintf("must equal %v", *n.constVal),
+			"must equal "+format(*n.constVal),
 			val, n.config.makeRuleVal(*n.constVal)))
 		if cfg.failFast {
 			return &ValidationError{Violations: violations}
@@ -601,7 +602,31 @@ func ptr[T any](v T) *T { return &v }
 func formatList[T any](vals []T) string {
 	parts := make([]string, len(vals))
 	for i, v := range vals {
-		parts[i] = fmt.Sprintf("%v", v)
+		parts[i] = format(v)
 	}
 	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+func format(v any) string {
+	switch val := v.(type) {
+	case float32:
+		return printFloat(float64(val))
+	case float64:
+		return printFloat(val)
+	default:
+		return fmt.Sprintf("%v", val)
+	}
+}
+
+func printFloat(argDbl float64) string {
+	if math.IsNaN(argDbl) {
+		return "NaN"
+	}
+	if math.IsInf(argDbl, -1) {
+		return "-Infinity"
+	}
+	if math.IsInf(argDbl, 1) {
+		return "Infinity"
+	}
+	return strconv.FormatFloat(argDbl, 'f', -1, 64)
 }

--- a/native_numeric_test.go
+++ b/native_numeric_test.go
@@ -412,6 +412,28 @@ func TestNativeFloat_NaN(t *testing.T) {
 	}
 }
 
+func TestNativeFloatNaNGT(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		rules *validate.FloatRules
+	}{
+		{"gt", validate.FloatRules_builder{Gt: proto.Float32(float32(math.NaN()))}.Build()},
+		{"lt", validate.FloatRules_builder{Lt: proto.Float32(float32(math.NaN()))}.Build()},
+		{"lte", validate.FloatRules_builder{Lte: proto.Float32(float32(math.NaN()))}.Build()},
+		{"gte", validate.FloatRules_builder{Gte: proto.Float32(float32(math.NaN()))}.Build()},
+		{"gte_lte", validate.FloatRules_builder{Gte: proto.Float32(float32(math.NaN())), Lte: proto.Float32(float32(math.NaN()))}.Build()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			eval := buildNativeNumeric(t, tt.rules, &floatConfig, descriptorpb.FieldDescriptorProto_TYPE_FLOAT)
+			require.Nil(t, eval)
+		})
+	}
+}
+
 func TestNativeFloat_FiniteDoesNotBailToCEL(t *testing.T) {
 	t.Parallel()
 	rules := validate.FloatRules_builder{Finite: proto.Bool(true), Gt: proto.Float32(0)}.Build()

--- a/native_string.go
+++ b/native_string.go
@@ -243,7 +243,7 @@ var (
 	tuuidRegexp       = regexp.MustCompile(`^[0-9a-fA-F]{32}$`)
 	ulidRegexp        = regexp.MustCompile(`^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$`)
 	looseRegexp       = regexp.MustCompile(`^[^\x00\x0A\x0D]+$`)
-	headerNameRegexp  = regexp.MustCompile(`^:?[0-9a-zA-Z!#$%&\\'*+-.^_|~\x60]+$`)
+	headerNameRegexp  = regexp.MustCompile(`^:?[0-9a-zA-Z!#$%&'*+.\-^_|~\x60]+$`)
 	headerValueRegexp = regexp.MustCompile(`^[^\x00-\x08\x0A-\x1F\x7F]*$`)
 )
 

--- a/native_string_test.go
+++ b/native_string_test.go
@@ -485,3 +485,90 @@ func TestNativeStringTautology(t *testing.T) {
 	require.NotNil(t, eval)
 	assert.False(t, eval.Tautology())
 }
+
+func TestHeaderNameRegex(t *testing.T) {
+	t.Parallel()
+	data := []struct {
+		HeaderName string
+		Valid      bool
+	}{
+		// true
+		{"Content-Type", true},
+		{"Content-Length", true},
+		{"Accept", true},
+		{"User-Agent", true},
+		{"X-Forwarded-For", true},
+		{"WWW-Authenticate", true},
+		{"If-None-Match", true},
+		{"Cache-Control", true},
+		{"Set-Cookie", true},
+		{"ETag", true},
+		{":method", true},
+		{":path", true},
+		{":status", true},
+		{":authority", true},
+		{":scheme", true},
+		{"!", true},
+		{"#", true},
+		{"$", true},
+		{"%", true},
+		{"&", true},
+		{"'", true},
+		{"*", true},
+		{"+", true},
+		{"-", true},
+		{".", true},
+		{"^", true},
+		{"_", true},
+		{"`", true},
+		{"|", true},
+		{"~", true},
+		{"a", true},
+		{"0", true},
+		{":a", true},
+		{"A1!#$%&'*+-.^_|~`", true},
+		{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", true},
+		{"MiXeDcAsE", true},
+		// false
+		{"Content-Type: application/json", false},
+		{"", false},
+		{":", false},
+		{" ", false},
+		{"Content-Type ", false},
+		{" Content-Type", false},
+		{"Content Type", false},
+		{"\tContent-Type", false},
+		{"Content:Type", false},
+		{"Content/Type", false},
+		{"Content\\Type", false},
+		{"Content,Type", false},
+		{"Content;Type", false},
+		{"Content=Type", false},
+		{"Content(Type)", false},
+		{"Content[Type]", false},
+		{"Content{Type}", false},
+		{"Content<Type>", false},
+		{"Content\"Type", false},
+		{"Content?Type", false},
+		{"Content@Type", false},
+		{"::method", false},
+		{"method:", false},
+		{":method:extra", false},
+		{"Conténg", false},
+		{"内容类型", false},
+		{"Header™", false},
+		{"naïve", false},
+		{"Content\x00Type", false},
+		{"Content\x7FType", false},
+		{"Content\nType", false},
+		{"Content\rType", false},
+		{"Valid-Name\nAnother-Name", false},
+	}
+	for _, d := range data {
+		t.Run(d.HeaderName, func(t *testing.T) {
+			t.Parallel()
+			valid := headerNameRegexp.MatchString(d.HeaderName)
+			assert.Equal(t, d.Valid, valid)
+		})
+	}
+}


### PR DESCRIPTION
While porting native rules to protovalidate-java, several issues were found in the protovalidate-go native rules implementation. This PR addresses those issues:

- if a protovalidate rule specifies NaN for a gt/lt/gte/lte, fall through to the CEL rule implementation (these protovalidate rules are invalid, let CEL generate the error message)
- in some cases, formatting for floating point numbers didn't match between CEL and native rules. Now they do.
- the regular expression to validate a string field as a valid http header name was incorrect. It has been updated.