### PR TITLE
Exclude the trailing dot from the hostname 253-character limit

### DIFF
--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -130,14 +130,16 @@ func IsIPPrefix(
 //   - The name can have a trailing dot, for example "foo.example.com.".
 //   - The name can be 253 characters at most, excluding the optional trailing dot.
 func IsHostname(val string) bool {
-	if len(val) > 253 {
-		return false
-	}
 	var str string
 	if strings.HasSuffix(val, ".") {
 		str = val[0 : len(val)-1]
 	} else {
 		str = val
+	}
+	// The 253-character limit excludes the optional trailing dot, so measure
+	// after stripping it.
+	if len(str) > 253 {
+		return false
 	}
 
 	allDigits := false

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -15,6 +15,7 @@
 package rules
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,6 +31,16 @@ func TestIsHostname(t *testing.T) {
 	require.True(t, IsHostname("foo.example.com"))
 	require.True(t, IsHostname("A.ISI.EDU"))
 	require.False(t, IsHostname("İ"))
+
+	// The 253-character limit excludes the optional trailing dot.
+	name253 := strings.Repeat("a", 63) + "." + strings.Repeat("a", 63) + "." +
+		strings.Repeat("a", 63) + "." + strings.Repeat("a", 61)
+	name254 := strings.Repeat("a", 63) + "." + strings.Repeat("a", 63) + "." +
+		strings.Repeat("a", 63) + "." + strings.Repeat("a", 62)
+	require.True(t, IsHostname(name253))
+	require.True(t, IsHostname(name253+"."))
+	require.False(t, IsHostname(name254))
+	require.False(t, IsHostname(name254+"."))
 }
 
 func TestIsHostAndPort(t *testing.T) {


### PR DESCRIPTION
`IsHostname` checked the length before stripping the trailing dot, so a valid 253-character name with a trailing dot (254 bytes) got rejected. The 253 limit excludes that optional dot, so it should pass. Fix is to strip the dot first, then check the length.

This is the runtime side of bufbuild/protovalidate#512. The matching conformance case `valid/name_253_characters_plus_trailing_dot` landed in bufbuild/protovalidate#513, and @rodaine suggested following up with the implementation patches.

Added boundary cases to `TestIsHostname` (253 + dot valid, 254 and 254 + dot still invalid).
