### PR TITLE
Use native rules for repeated item rules

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -474,24 +474,24 @@ func (bldr *builder) processStandardRules(
 	// reused (happens in some test cases, could happen in production code with dynamic messages).
 	rules = proto.CloneOf[*validate.FieldRules](rules)
 
-	// put behind a feature flag to allow for testing.
-	// it's easier to follow like this, don't break it up
-	//nolint:nestif
+	// Try native Go evaluators for known simple rules before falling back to
+	// CEL. put behind a feature flag to allow for testing.
 	if !bldr.disableNativeRules {
-		// Try native Go evaluators for repeated list-level rules (min_items, max_items, unique).
-		if fdesc.IsList() && valEval.NestedRule == nil {
+		switch {
+		case fdesc.IsList() && valEval.NestedRule == nil:
+			// List-level rules (min_items, max_items, unique).
 			if native := tryNativeRepeatedRules(newBase(valEval), rules.GetRepeated()); native != nil {
 				valEval.Append(native)
 			}
-		}
-		// Try native Go evaluators for map-level rules (min_pairs, max_pairs).
-		if fdesc.IsMap() && valEval.NestedRule == nil {
+		case fdesc.IsMap() && valEval.NestedRule == nil:
+			// Map-level rules (min_pairs, max_pairs).
 			if native := tryNativeMapRules(newBase(valEval), rules.GetMap()); native != nil {
 				valEval.Append(native)
 			}
-		}
-		// Try native Go evaluators for known simple rules before falling back to CEL.
-		if !fdesc.IsMap() && (!fdesc.IsList() || valEval.NestedRule != nil) {
+		default:
+			// Scalar rules for plain fields, map keys/values, and repeated
+			// items. A non-nil NestedRule means we're compiling rules for an
+			// individual item, not the list itself.
 			if native := bldr.tryNativeRules(fdesc, rules, valEval); native != nil {
 				valEval.Append(native)
 			}

--- a/builder.go
+++ b/builder.go
@@ -483,7 +483,7 @@ func (bldr *builder) processStandardRules(
 			if native := tryNativeRepeatedRules(newBase(valEval), rules.GetRepeated()); native != nil {
 				valEval.Append(native)
 			}
-		case fdesc.IsMap() && valEval.NestedRule == nil:
+		case fdesc.IsMap():
 			// Map-level rules (min_pairs, max_pairs).
 			if native := tryNativeMapRules(newBase(valEval), rules.GetMap()); native != nil {
 				valEval.Append(native)

--- a/builder.go
+++ b/builder.go
@@ -491,7 +491,7 @@ func (bldr *builder) processStandardRules(
 			}
 		}
 		// Try native Go evaluators for known simple rules before falling back to CEL.
-		if !fdesc.IsMap() && !fdesc.IsList() {
+		if !fdesc.IsMap() && (!fdesc.IsList() || valEval.NestedRule != nil) {
 			if native := bldr.tryNativeRules(fdesc, rules, valEval); native != nil {
 				valEval.Append(native)
 			}


### PR DESCRIPTION
`repeated.items` rules always fell back to CEL, even with native rules enabled. The native evaluators already work per-element, so letting the dispatch run for items is enough: a validate of a 1,000-item field with `items.int32.gt` drops from 96 µs to 20 µs, and the repo benchmarks improve 1.5–4.7%.

```proto
message Review {
  repeated int32 ratings = 1 [(buf.validate.field).repeated = {
    max_items: 100 // native
    items: {
      int32: {
        gte: 1 // Executes in CEL for each element
        lte: 5 // Executes in CEL for each element
      }
    }
  }];
}
```